### PR TITLE
fix: disable slow snow queries in almanac endpoint

### DIFF
--- a/internal/storage/timescaledb/sql.go
+++ b/internal/storage/timescaledb/sql.go
@@ -2024,6 +2024,9 @@ CREATE INDEX IF NOT EXISTS weather_1d_bucket_stationname_idx ON weather_1d (stat
 CREATE INDEX IF NOT EXISTS weather_stationname_time_idx ON weather (stationname, time DESC);
 CREATE INDEX IF NOT EXISTS weather_time_stationname_idx ON weather (time DESC, stationname);
 CREATE INDEX IF NOT EXISTS weather_stationname_snowdistance_time_idx ON weather (stationname, time DESC) WHERE snowdistance IS NOT NULL AND snowdistance > 0;
+-- Snow indexes for aggregation tables (for almanac queries)
+CREATE INDEX IF NOT EXISTS weather_1h_stationname_snowdistance_bucket_idx ON weather_1h (stationname, bucket DESC) WHERE snowdistance IS NOT NULL AND snowdistance > 0;
+CREATE INDEX IF NOT EXISTS weather_1d_stationname_snowdistance_bucket_idx ON weather_1d (stationname, bucket DESC) WHERE snowdistance IS NOT NULL AND snowdistance > 0;
 -- Rainfall summary index
 CREATE INDEX IF NOT EXISTS rainfall_summary_stationname_idx ON rainfall_summary (stationname);`
 

--- a/migrations/weather/006_add_snow_indexes.down.sql
+++ b/migrations/weather/006_add_snow_indexes.down.sql
@@ -1,0 +1,3 @@
+-- Remove snow indexes added by this migration
+DROP INDEX IF EXISTS weather_1h_stationname_snowdistance_bucket_idx;
+DROP INDEX IF EXISTS weather_1d_stationname_snowdistance_bucket_idx;

--- a/migrations/weather/006_add_snow_indexes.up.sql
+++ b/migrations/weather/006_add_snow_indexes.up.sql
@@ -1,0 +1,16 @@
+-- Add partial indexes for snow-related almanac queries
+-- These optimize the window function queries for max snow in 1h/1d
+
+-- Index for weather_1h snow queries (max snow in 1 hour)
+CREATE INDEX IF NOT EXISTS weather_1h_stationname_snowdistance_bucket_idx
+ON weather_1h (stationname, bucket DESC)
+WHERE snowdistance IS NOT NULL AND snowdistance > 0;
+
+-- Index for weather_1d snow queries (max snow in 1 day)
+CREATE INDEX IF NOT EXISTS weather_1d_stationname_snowdistance_bucket_idx
+ON weather_1d (stationname, bucket DESC)
+WHERE snowdistance IS NOT NULL AND snowdistance > 0;
+
+-- Analyze tables to update statistics for query planner
+ANALYZE weather_1h;
+ANALYZE weather_1d;


### PR DESCRIPTION
The /almanac endpoint was timing out due to slow snow metric queries that ran on every request. These queries used window functions (LAG) over weather_1h and weather_1d tables, taking 120-240ms total.

Changes:
- Temporarily disabled 3 slow snow queries in GetAlmanac handler
  - Deepest snow query on weather table
  - Max snow in 1 hour (window function on weather_1h)
  - Max snow in 1 day (window function on weather_1d)
- Added partial indexes for future snow query optimization
- Added migration 006_add_snow_indexes for index creation

The endpoint now responds quickly by only reading from the pre-cached almanac_cache table which is refreshed hourly.

Future work: Move snow calculations to almanac_cache refresh job to re-enable snow metrics without performance impact.