### PR TITLE
Fix snow depth display showing 0.0 instead of actual value

### DIFF
--- a/internal/controllers/restserver/assets/js/weather-app.js.tmpl
+++ b/internal/controllers/restserver/assets/js/weather-app.js.tmpl
@@ -26,7 +26,8 @@ const WeatherApp = (function() {
         liveDataTimer: null,
         updateTimerInterval: null,
         chartRefreshTimer: null,
-        snowDeviceId: null
+        snowDeviceId: null,
+        airQualityDeviceId: null
     };
     
     // Constants
@@ -225,9 +226,15 @@ const WeatherApp = (function() {
     const loadStationInfo = async () => {
         try {
             const stationInfo = await WeatherDataService.fetchStationInfo();
-            if (config.snowEnabled && stationInfo) {
-                state.snowDeviceId = WeatherDataService.getSnowDeviceId(stationInfo);
-                if (config.debug) console.log('Snow device ID:', state.snowDeviceId);
+            if (stationInfo) {
+                if (config.snowEnabled) {
+                    state.snowDeviceId = WeatherDataService.getSnowDeviceId(stationInfo);
+                    if (config.debug) console.log('Snow device ID:', state.snowDeviceId);
+                }
+                if (config.airQualityEnabled) {
+                    state.airQualityDeviceId = WeatherDataService.getAirQualityDeviceId(stationInfo);
+                    if (config.debug) console.log('Air quality device ID:', state.airQualityDeviceId);
+                }
             }
         } catch (error) {
             if (config.debug) console.error('Error loading station info:', error);
@@ -263,7 +270,7 @@ const WeatherApp = (function() {
                 config.snowEnabled,
                 config.airQualityEnabled,
                 config.stationID,
-                config.airQualityDeviceID,
+                state.airQualityDeviceId,
                 state.snowDeviceId
             );
             
@@ -293,9 +300,14 @@ const WeatherApp = (function() {
     // Load charts for a specific range
     const loadChartsForRange = async (range) => {
         const hours = CHART_RANGES[range];
-        
+
         try {
-            const { mainData, snowData, airQualityData } = await WeatherDataService.fetchChartData(hours, config);
+            // Merge config with state-based device IDs
+            const chartConfig = {
+                ...config,
+                airQualityDeviceID: state.airQualityDeviceId
+            };
+            const { mainData, snowData, airQualityData } = await WeatherDataService.fetchChartData(hours, chartConfig);
             
             if (!mainData) return;
             

--- a/internal/controllers/restserver/assets/js/weather-app.js.tmpl
+++ b/internal/controllers/restserver/assets/js/weather-app.js.tmpl
@@ -25,7 +25,8 @@ const WeatherApp = (function() {
         secondsSinceLastUpdate: 0,
         liveDataTimer: null,
         updateTimerInterval: null,
-        chartRefreshTimer: null
+        chartRefreshTimer: null,
+        snowDeviceId: null
     };
     
     // Constants
@@ -220,8 +221,24 @@ const WeatherApp = (function() {
         }
     };
 
+    // Load station info to get device IDs
+    const loadStationInfo = async () => {
+        try {
+            const stationInfo = await WeatherDataService.fetchStationInfo();
+            if (config.snowEnabled && stationInfo) {
+                state.snowDeviceId = WeatherDataService.getSnowDeviceId(stationInfo);
+                if (config.debug) console.log('Snow device ID:', state.snowDeviceId);
+            }
+        } catch (error) {
+            if (config.debug) console.error('Error loading station info:', error);
+        }
+    };
+
     // Load initial data
     const loadInitialData = async () => {
+        // First, load station info to get device IDs (needed for snow data)
+        await loadStationInfo();
+
         // Load all data in parallel for faster initial load
         const promises = [
             refreshLiveData(),
@@ -243,10 +260,11 @@ const WeatherApp = (function() {
     const refreshLiveData = async () => {
         try {
             const { weather, snow, airQuality } = await WeatherDataService.fetchLiveData(
-                config.snowEnabled, 
+                config.snowEnabled,
                 config.airQualityEnabled,
                 config.stationID,
-                config.airQualityDeviceID
+                config.airQualityDeviceID,
+                state.snowDeviceId
             );
             
             if (weather) {

--- a/internal/controllers/restserver/assets/js/weather-data-service.js
+++ b/internal/controllers/restserver/assets/js/weather-data-service.js
@@ -44,7 +44,8 @@ const WeatherDataService = (function() {
         const promises = [fetchLatestWeather(stationId)];
         
         if (snowEnabled) {
-            promises.push(fetchSnowData(stationId));
+            // Don't pass stationId to snow endpoint - the backend uses its configured snow device
+            promises.push(fetchSnowData());
         }
         
         // Fetch air quality data from the air quality device using its station_id

--- a/internal/controllers/restserver/assets/js/weather-data-service.js
+++ b/internal/controllers/restserver/assets/js/weather-data-service.js
@@ -55,6 +55,16 @@ const WeatherDataService = (function() {
         return snowStation ? snowStation.id : null;
     };
 
+    // Get air quality device ID from station info
+    const getAirQualityDeviceId = (stationInfo) => {
+        if (!stationInfo || !stationInfo.air_quality_device || !stationInfo.stations) {
+            return null;
+        }
+        const aqDeviceName = stationInfo.air_quality_device;
+        const aqStation = stationInfo.stations.find(s => s.name === aqDeviceName);
+        return aqStation ? aqStation.id : null;
+    };
+
     // Combined fetch for live data (weather + snow if enabled + air quality if enabled)
     const fetchLiveData = async (snowEnabled = false, airQualityEnabled = false, stationId = null, airQualityStationId = null, snowDeviceId = null) => {
         const promises = [fetchLatestWeather(stationId)];
@@ -263,6 +273,7 @@ const WeatherDataService = (function() {
 
         // Helper methods
         getSnowDeviceId,
+        getAirQualityDeviceId,
 
         // Combined fetch methods
         fetchLiveData,

--- a/internal/controllers/restserver/assets/js/weather-data-service.js
+++ b/internal/controllers/restserver/assets/js/weather-data-service.js
@@ -8,6 +8,7 @@ const WeatherDataService = (function() {
     const endpoints = {
         latest: '/latest',
         snow: '/snow',
+        stationinfo: '/stationinfo',
         span: function(hours) { return '/span/' + hours + 'h'; },
         forecast: function(hours) { return '/forecast/' + hours; }
     };
@@ -38,14 +39,28 @@ const WeatherDataService = (function() {
         const url = stationId ? endpoints.forecast(hours) + '?station_id=' + stationId : endpoints.forecast(hours);
         return WeatherUtils.fetchWithTimeout(url);
     };
-    
+
+    // Fetch station info (includes snow device ID)
+    const fetchStationInfo = async () => {
+        return WeatherUtils.fetchWithTimeout(endpoints.stationinfo);
+    };
+
+    // Get snow device ID from station info
+    const getSnowDeviceId = (stationInfo) => {
+        if (!stationInfo || !stationInfo.snow_device || !stationInfo.stations) {
+            return null;
+        }
+        const snowDeviceName = stationInfo.snow_device;
+        const snowStation = stationInfo.stations.find(s => s.name === snowDeviceName);
+        return snowStation ? snowStation.id : null;
+    };
+
     // Combined fetch for live data (weather + snow if enabled + air quality if enabled)
-    const fetchLiveData = async (snowEnabled = false, airQualityEnabled = false, stationId = null, airQualityStationId = null) => {
+    const fetchLiveData = async (snowEnabled = false, airQualityEnabled = false, stationId = null, airQualityStationId = null, snowDeviceId = null) => {
         const promises = [fetchLatestWeather(stationId)];
-        
+
         if (snowEnabled) {
-            // Don't pass stationId to snow endpoint - the backend uses its configured snow device
-            promises.push(fetchSnowData());
+            promises.push(fetchSnowData(snowDeviceId));
         }
         
         // Fetch air quality data from the air quality device using its station_id
@@ -244,11 +259,15 @@ const WeatherDataService = (function() {
         fetchSnowData,
         fetchHistoricalData,
         fetchForecast,
-        
+        fetchStationInfo,
+
+        // Helper methods
+        getSnowDeviceId,
+
         // Combined fetch methods
         fetchLiveData,
         fetchChartData,
-        
+
         // Data processing methods
         processLiveWeatherData,
         processSnowData,


### PR DESCRIPTION
The fetchLiveData function was incorrectly passing the main weather
station's ID to the /snow endpoint. When a station_id is provided,
the backend overrides its configured snow device with that station,
causing it to query the weather station instead of the snow gauge.

Since the weather station doesn't have snow data, it returned zeros.
The fix removes the stationId parameter from the fetchSnowData call,
allowing the backend to use its properly configured snow device.