### PR TITLE
Live weather radar for the station website

### DIFF
--- a/internal/controllers/management/assets/css/style.css
+++ b/internal/controllers/management/assets/css/style.css
@@ -135,6 +135,16 @@ h2 {
   background: #14768c;
 }
 
+.primary-btn:disabled,
+.secondary-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.primary-btn:disabled:hover {
+  background: var(--accent);
+}
+
 .secondary-btn {
   background: #ccc;
   color: #000;

--- a/internal/controllers/management/assets/index.html
+++ b/internal/controllers/management/assets/index.html
@@ -748,7 +748,27 @@
             <input type="text" id="website-tls-key" placeholder="/path/to/key.pem" />
           </label>
         </fieldset>
-        
+
+        <fieldset>
+          <legend>Weather Radar</legend>
+          <p class="help-text" id="radar-status">Radar is not enabled for this site.</p>
+          <div id="radar-register-block">
+            <p class="help-text">
+              <b>Non-commercial use only.</b> These maps and weather radar are provided for personal,
+              non-commercial use only. By enabling radar on this site you agree not to use the map or
+              radar imagery for any commercial purpose.
+            </p>
+            <label class="checkbox-label">
+              <input type="checkbox" id="radar-agree" />
+              I agree to the non-commercial use terms
+            </label>
+            <button type="button" id="radar-register-btn" disabled>Register for radar access</button>
+          </div>
+          <div id="radar-registered-block" style="display:none;">
+            <button type="button" id="radar-disable-btn" class="btn-danger">Disable radar</button>
+          </div>
+        </fieldset>
+
         <div class="modal-footer">
           <button type="button" class="secondary-btn" id="cancel-website-btn">Cancel</button>
           <button type="submit" class="primary-btn" id="save-website-btn">Save</button>

--- a/internal/controllers/management/assets/index.html
+++ b/internal/controllers/management/assets/index.html
@@ -751,7 +751,11 @@
 
         <fieldset>
           <legend>Weather Radar</legend>
-          <p class="help-text" id="radar-status">Radar is not enabled for this site.</p>
+          <p class="help-text">
+            Radar status:
+            <span class="status-badge status-offline" id="radar-status-badge">Not enabled</span>
+            <span id="radar-status"></span>
+          </p>
           <div id="radar-register-block">
             <p class="help-text">
               <b>Non-commercial use only.</b> These maps and weather radar are provided for personal,
@@ -762,7 +766,7 @@
               <input type="checkbox" id="radar-agree" />
               I agree to the non-commercial use terms
             </label>
-            <button type="button" id="radar-register-btn" disabled>Register for radar access</button>
+            <button type="button" id="radar-register-btn" class="primary-btn" disabled>Register for radar access</button>
           </div>
           <div id="radar-registered-block" style="display:none;">
             <button type="button" id="radar-disable-btn" class="btn-danger">Disable radar</button>

--- a/internal/controllers/management/assets/js/management-api-service.js
+++ b/internal/controllers/management/assets/js/management-api-service.js
@@ -281,6 +281,14 @@ const ManagementAPIService = (function() {
     }
   }
 
+  async function registerRadar(id) {
+    return await apiPost(`/config/websites/${id}/radar/register`, { agree_noncommercial: true });
+  }
+
+  async function unregisterRadar(id) {
+    return await apiDelete(`/config/websites/${id}/radar/register`);
+  }
+
   /* ---------------------------------------------------
      Logs API
   --------------------------------------------------- */
@@ -377,6 +385,8 @@ const ManagementAPIService = (function() {
     saveWebsite,
     deleteWebsite,
     savePortal,
+    registerRadar,
+    unregisterRadar,
     
     // Logs
     getLogs,

--- a/internal/controllers/management/assets/js/management-websites.js
+++ b/internal/controllers/management/assets/js/management-websites.js
@@ -58,7 +58,13 @@ const ManagementWebsites = (function() {
 
       airQualityEnabled: document.getElementById('website-airquality-enabled'),
       airQualityDevice: document.getElementById('website-airquality-device'),
-      airQualityDeviceLabel: document.getElementById('airquality-device-label')
+      airQualityDeviceLabel: document.getElementById('airquality-device-label'),
+      radarStatus: document.getElementById('radar-status'),
+      radarRegisterBlock: document.getElementById('radar-register-block'),
+      radarRegisteredBlock: document.getElementById('radar-registered-block'),
+      radarAgree: document.getElementById('radar-agree'),
+      radarRegisterBtn: document.getElementById('radar-register-btn'),
+      radarDisableBtn: document.getElementById('radar-disable-btn')
     };
 
     // Portal form elements
@@ -219,9 +225,42 @@ const ManagementWebsites = (function() {
     resetWebsiteForm();
     websiteModalElements.modalTitle.textContent = 'Add Weather Website';
     websiteFormElements.formMode.value = 'add';
+    renderRadarPanel(null);
     websiteModalElements.modal.classList.remove('hidden');
     loadDeviceSelectsForWebsite();
     setupSnowToggle();
+  }
+
+  // renderRadarPanel reflects a website's radar registration state in the modal.
+  // Passing null (the add path) shows the "save first" hint.
+  function renderRadarPanel(website) {
+    const el = websiteFormElements;
+    if (!el.radarStatus) {
+      return;
+    }
+    const enabled = !!(website && website.radar_enabled);
+    const id = website && website.id;
+    el.radarAgree.checked = false;
+    el.radarRegisterBtn.disabled = true;
+
+    if (!id) {
+      el.radarStatus.textContent = 'Save the website first, then register for radar.';
+      el.radarRegisterBlock.style.display = 'none';
+      el.radarRegisteredBlock.style.display = 'none';
+      return;
+    }
+    if (enabled) {
+      const when = website.radar_registered_at
+        ? new Date(website.radar_registered_at * 1000).toLocaleString()
+        : 'unknown date';
+      el.radarStatus.textContent = `Radar enabled (registered ${when}).`;
+      el.radarRegisterBlock.style.display = 'none';
+      el.radarRegisteredBlock.style.display = 'block';
+    } else {
+      el.radarStatus.textContent = 'Radar is not enabled for this site.';
+      el.radarRegisterBlock.style.display = 'block';
+      el.radarRegisteredBlock.style.display = 'none';
+    }
   }
 
   function closeWebsiteModal() {
@@ -282,7 +321,9 @@ const ManagementWebsites = (function() {
       } else {
         websiteFormElements.airQualityDevice.style.opacity = '0.6';
       }
-      
+
+      renderRadarPanel(website);
+
       websiteModalElements.modal.classList.remove('hidden');
     } catch (err) {
       alert('Failed to load website: ' + err.message);
@@ -519,6 +560,44 @@ const ManagementWebsites = (function() {
       portalFormElements.form.addEventListener('submit', (e) => {
         e.preventDefault();
         savePortal();
+      });
+    }
+
+    // Radar registration panel
+    if (websiteFormElements.radarAgree) {
+      websiteFormElements.radarAgree.addEventListener('change', () => {
+        websiteFormElements.radarRegisterBtn.disabled = !websiteFormElements.radarAgree.checked;
+      });
+    }
+    if (websiteFormElements.radarRegisterBtn) {
+      websiteFormElements.radarRegisterBtn.addEventListener('click', async () => {
+        const id = websiteFormElements.editId.value;
+        if (!id) {
+          alert('Save the website first.');
+          return;
+        }
+        websiteFormElements.radarRegisterBtn.disabled = true;
+        try {
+          await ManagementAPIService.registerRadar(id);
+          renderRadarPanel(await ManagementAPIService.getWebsite(id));
+        } catch (err) {
+          alert('Radar registration failed: ' + err.message);
+          websiteFormElements.radarRegisterBtn.disabled = false;
+        }
+      });
+    }
+    if (websiteFormElements.radarDisableBtn) {
+      websiteFormElements.radarDisableBtn.addEventListener('click', async () => {
+        const id = websiteFormElements.editId.value;
+        if (!id) {
+          return;
+        }
+        try {
+          await ManagementAPIService.unregisterRadar(id);
+          renderRadarPanel(await ManagementAPIService.getWebsite(id));
+        } catch (err) {
+          alert('Failed to disable radar: ' + err.message);
+        }
       });
     }
   }

--- a/internal/controllers/management/assets/js/management-websites.js
+++ b/internal/controllers/management/assets/js/management-websites.js
@@ -60,6 +60,7 @@ const ManagementWebsites = (function() {
       airQualityDevice: document.getElementById('website-airquality-device'),
       airQualityDeviceLabel: document.getElementById('airquality-device-label'),
       radarStatus: document.getElementById('radar-status'),
+      radarStatusBadge: document.getElementById('radar-status-badge'),
       radarRegisterBlock: document.getElementById('radar-register-block'),
       radarRegisteredBlock: document.getElementById('radar-registered-block'),
       radarAgree: document.getElementById('radar-agree'),
@@ -243,7 +244,15 @@ const ManagementWebsites = (function() {
     el.radarAgree.checked = false;
     el.radarRegisterBtn.disabled = true;
 
+    const setBadge = (text, online) => {
+      if (!el.radarStatusBadge) return;
+      el.radarStatusBadge.textContent = text;
+      el.radarStatusBadge.classList.toggle('status-online', online);
+      el.radarStatusBadge.classList.toggle('status-offline', !online);
+    };
+
     if (!id) {
+      setBadge('Not enabled', false);
       el.radarStatus.textContent = 'Save the website first, then register for radar.';
       el.radarRegisterBlock.style.display = 'none';
       el.radarRegisteredBlock.style.display = 'none';
@@ -253,11 +262,13 @@ const ManagementWebsites = (function() {
       const when = website.radar_registered_at
         ? new Date(website.radar_registered_at * 1000).toLocaleString()
         : 'unknown date';
-      el.radarStatus.textContent = `Radar enabled (registered ${when}).`;
+      setBadge('Enabled', true);
+      el.radarStatus.textContent = `Registered ${when}.`;
       el.radarRegisterBlock.style.display = 'none';
       el.radarRegisteredBlock.style.display = 'block';
     } else {
-      el.radarStatus.textContent = 'Radar is not enabled for this site.';
+      setBadge('Not enabled', false);
+      el.radarStatus.textContent = '';
       el.radarRegisterBlock.style.display = 'block';
       el.radarRegisteredBlock.style.display = 'none';
     }

--- a/internal/controllers/management/controller.go
+++ b/internal/controllers/management/controller.go
@@ -211,6 +211,8 @@ func (c *Controller) setupRouter() *mux.Router {
 	api.HandleFunc("/config/websites/{id}", c.handlers.GetWeatherWebsite).Methods("GET")
 	api.HandleFunc("/config/websites/{id}", c.handlers.UpdateWeatherWebsite).Methods("PUT")
 	api.HandleFunc("/config/websites/{id}", c.handlers.DeleteWeatherWebsite).Methods("DELETE")
+	api.HandleFunc("/config/websites/{id}/radar/register", c.handlers.RegisterWebsiteRadar).Methods("POST")
+	api.HandleFunc("/config/websites/{id}/radar/register", c.handlers.UnregisterWebsiteRadar).Methods("DELETE")
 
 	// Testing/connectivity endpoints
 	api.HandleFunc("/test/device", c.handlers.TestDeviceConnectivity).Methods("POST")

--- a/internal/controllers/management/handlers_websites.go
+++ b/internal/controllers/management/handlers_websites.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/chrissnell/remoteweather/pkg/config"
 	"github.com/gorilla/mux"
@@ -291,4 +292,92 @@ func (h *Handlers) DeleteWeatherWebsite(w http.ResponseWriter, r *http.Request) 
 	h.sendJSON(w, map[string]interface{}{
 		"message": "Weather website deleted successfully",
 	})
+}
+
+// RegisterWebsiteRadar registers the website's hostname with the Graywolf maps
+// service (recording the non-commercial agreement) and enables radar on success.
+func (h *Handlers) RegisterWebsiteRadar(w http.ResponseWriter, r *http.Request) {
+	if h.controller.ConfigProvider.IsReadOnly() {
+		h.sendError(w, http.StatusBadRequest, "Configuration is read-only", nil)
+		return
+	}
+
+	id, err := strconv.Atoi(mux.Vars(r)["id"])
+	if err != nil {
+		h.sendError(w, http.StatusBadRequest, "Invalid website ID", err)
+		return
+	}
+
+	var body struct {
+		AgreeNoncommercial bool `json:"agree_noncommercial"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		h.sendError(w, http.StatusBadRequest, "Invalid JSON", err)
+		return
+	}
+	if !body.AgreeNoncommercial {
+		h.sendError(w, http.StatusBadRequest, "Non-commercial agreement is required", nil)
+		return
+	}
+
+	website, err := h.controller.ConfigProvider.GetWeatherWebsite(id)
+	if err != nil {
+		h.sendError(w, http.StatusNotFound, "Weather website not found", err)
+		return
+	}
+	if website.Hostname == "" {
+		h.sendError(w, http.StatusBadRequest, "Website must have a hostname before enabling radar", nil)
+		return
+	}
+
+	token, err := registerRadarToken(website.Hostname)
+	if err != nil {
+		h.sendError(w, http.StatusBadGateway, "Radar registration failed", err)
+		return
+	}
+
+	now := time.Now().Unix()
+	if err := h.controller.ConfigProvider.SetWebsiteRadarRegistration(id, token, now); err != nil {
+		h.sendError(w, http.StatusInternalServerError, "Failed to save radar registration", err)
+		return
+	}
+
+	h.reloadWebsiteConfig()
+	h.sendJSON(w, map[string]interface{}{
+		"registered":          true,
+		"radar_registered_at": now,
+	})
+}
+
+// UnregisterWebsiteRadar disables radar and clears the stored token.
+func (h *Handlers) UnregisterWebsiteRadar(w http.ResponseWriter, r *http.Request) {
+	if h.controller.ConfigProvider.IsReadOnly() {
+		h.sendError(w, http.StatusBadRequest, "Configuration is read-only", nil)
+		return
+	}
+	id, err := strconv.Atoi(mux.Vars(r)["id"])
+	if err != nil {
+		h.sendError(w, http.StatusBadRequest, "Invalid website ID", err)
+		return
+	}
+	if err := h.controller.ConfigProvider.ClearWebsiteRadarRegistration(id); err != nil {
+		h.sendError(w, http.StatusInternalServerError, "Failed to disable radar", err)
+		return
+	}
+	h.reloadWebsiteConfig()
+	h.sendJSON(w, map[string]interface{}{"registered": false})
+}
+
+// reloadWebsiteConfig triggers the REST controller to pick up config changes,
+// matching the pattern used by Create/UpdateWeatherWebsite.
+func (h *Handlers) reloadWebsiteConfig() {
+	if h.controller.app == nil {
+		return
+	}
+	type WebsiteReloader interface{ ReloadWebsiteConfiguration() error }
+	if reloader, ok := h.controller.app.(WebsiteReloader); ok {
+		if err := reloader.ReloadWebsiteConfiguration(); err != nil {
+			h.controller.logger.Errorf("Failed to reload website configuration: %v", err)
+		}
+	}
 }

--- a/internal/controllers/management/radar_register.go
+++ b/internal/controllers/management/radar_register.go
@@ -1,0 +1,62 @@
+package management
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// radarAuthBaseURL is the Graywolf auth worker base. Package var so tests can
+// redirect it to an httptest server.
+var radarAuthBaseURL = "https://auth.nw5w.com"
+
+type radarRegisterRequest struct {
+	Instance           string `json:"instance"`
+	AgreeNoncommercial bool   `json:"agree_noncommercial"`
+}
+
+type radarRegisterResponse struct {
+	Instance string `json:"instance"`
+	Token    string `json:"token"`
+	Error    string `json:"error"`
+}
+
+// registerRadarToken registers a website hostname with the Graywolf auth worker
+// (recording the non-commercial agreement) and returns the issued tile token.
+func registerRadarToken(hostname string) (string, error) {
+	payload, err := json.Marshal(radarRegisterRequest{Instance: hostname, AgreeNoncommercial: true})
+	if err != nil {
+		return "", fmt.Errorf("encoding radar registration request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, radarAuthBaseURL+"/register/remoteweather", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("creating radar registration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("calling radar registration: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var parsed radarRegisterResponse
+	_ = json.Unmarshal(bodyBytes, &parsed)
+
+	if resp.StatusCode != http.StatusOK {
+		if parsed.Error != "" {
+			return "", fmt.Errorf("radar registration failed: %s (HTTP %d)", parsed.Error, resp.StatusCode)
+		}
+		return "", fmt.Errorf("radar registration failed: HTTP %d", resp.StatusCode)
+	}
+	if parsed.Token == "" {
+		return "", fmt.Errorf("radar registration returned no token")
+	}
+	return parsed.Token, nil
+}

--- a/internal/controllers/management/radar_register_test.go
+++ b/internal/controllers/management/radar_register_test.go
@@ -1,0 +1,55 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterRadarToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/register/remoteweather" || r.Method != http.MethodPost {
+			http.Error(w, "bad route", http.StatusNotFound)
+			return
+		}
+		var body struct {
+			Instance           string `json:"instance"`
+			AgreeNoncommercial bool   `json:"agree_noncommercial"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Instance != "suncrestweather.com" || !body.AgreeNoncommercial {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"instance": body.Instance, "token": "tok-xyz"})
+	}))
+	defer srv.Close()
+
+	old := radarAuthBaseURL
+	radarAuthBaseURL = srv.URL
+	defer func() { radarAuthBaseURL = old }()
+
+	token, err := registerRadarToken("suncrestweather.com")
+	if err != nil {
+		t.Fatalf("registerRadarToken: %v", err)
+	}
+	if token != "tok-xyz" {
+		t.Errorf("token = %q, want tok-xyz", token)
+	}
+}
+
+func TestRegisterRadarTokenUpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "device_limit_reached"})
+	}))
+	defer srv.Close()
+	old := radarAuthBaseURL
+	radarAuthBaseURL = srv.URL
+	defer func() { radarAuthBaseURL = old }()
+
+	if _, err := registerRadarToken("suncrestweather.com"); err == nil {
+		t.Fatal("expected error on non-200 upstream")
+	}
+}

--- a/internal/controllers/restserver/assets/css/weather.css
+++ b/internal/controllers/restserver/assets/css/weather.css
@@ -1962,3 +1962,69 @@ html[data-theme="light"] .theme-toggle::before {
     grid-template-columns: 1fr;
   }
 }
+/* ---- Live radar + Air Quality row ---- */
+.radar-aq-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  max-width: 1400px;
+  margin: 16px auto 0;
+  align-items: stretch;
+}
+/* Air Quality: narrow 1x6 column on the left when paired. */
+.radar-aq-row .aq-block {
+  flex: 1 1 260px;
+  max-width: 320px;
+  margin-top: 0;
+}
+.radar-aq-row .aq-block .air-quality-metrics {
+  display: grid !important;
+  grid-template-columns: 1fr !important;   /* 1x6 */
+  gap: 8px;
+}
+/* Radar fills the rest on the right. */
+.radar-block {
+  flex: 3 1 480px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  padding: 16px;
+}
+#radar-map {
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 360px;
+  aspect-ratio: 16 / 10;
+  border-radius: 6px;
+  overflow: hidden;
+}
+#radar-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+#radar-controls button {
+  min-height: 36px;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+#radar-scrubber { flex: 1 1 auto; }
+#radar-timestamp { font-variant-numeric: tabular-nums; min-width: 4.5em; text-align: right; }
+
+/* Tablet/phone: stack; radar full width, AQ back to a 2-col grid. */
+@media (max-width: 900px) {
+  .radar-aq-row { flex-direction: column; }
+  .radar-aq-row .aq-block { max-width: none; flex-basis: auto; }
+  .radar-aq-row .aq-block .air-quality-metrics {
+    grid-template-columns: 1fr 1fr !important;
+  }
+  #radar-map { min-height: 280px; aspect-ratio: 4 / 3; max-height: 70vh; }
+}
+@media (max-width: 480px) {
+  #radar-controls { flex-wrap: wrap; }
+  #radar-controls button { min-height: 44px; }   /* touch target */
+  #radar-scrubber { flex-basis: 100%; height: 28px; }
+}

--- a/internal/controllers/restserver/assets/css/weather.css
+++ b/internal/controllers/restserver/assets/css/weather.css
@@ -1991,28 +1991,124 @@ html[data-theme="light"] .theme-toggle::before {
   border: 1px solid var(--border-primary);
   border-radius: 8px;
   padding: 16px;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+.radar-block .group-title {
+  margin-bottom: 12px;
 }
 #radar-map {
   width: 100%;
   flex: 1 1 auto;
   min-height: 360px;
   aspect-ratio: 16 / 10;
-  border-radius: 6px;
+  border-radius: 8px;
   overflow: hidden;
+  position: relative;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-primary);
 }
+/* Graceful framing before the first tiles paint (JS removes .is-loading on map load). */
+#radar-map.is-loading::after {
+  content: "Loading radar\2026";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  letter-spacing: 0.5px;
+  background: var(--bg-primary);
+}
+/* Controls sit on their own surface so the bar reads as one polished unit. */
 #radar-controls {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-top: 10px;
+  gap: 12px;
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
 }
 #radar-controls button {
   min-height: 36px;
-  padding: 6px 14px;
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  background: var(--bg-secondary);
+  color: var(--text-accent);
+  border: 1px solid var(--text-accent);
+  border-radius: 6px;
   cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.1s ease;
 }
-#radar-scrubber { flex: 1 1 auto; }
-#radar-timestamp { font-variant-numeric: tabular-nums; min-width: 4.5em; text-align: right; }
+#radar-controls button:hover {
+  background: var(--text-accent);
+  color: var(--bg-primary);
+}
+#radar-controls button:active {
+  transform: translateY(1px);
+}
+#radar-controls button:focus-visible {
+  outline: 2px solid var(--text-accent);
+  outline-offset: 2px;
+}
+#radar-controls button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+/* Custom dark-theme range slider (track + thumb), accent-colored. */
+#radar-scrubber {
+  flex: 1 1 auto;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--border-primary);
+  cursor: pointer;
+  outline: none;
+}
+#radar-scrubber::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-accent);
+  border: 2px solid var(--bg-secondary);
+  box-shadow: 0 1px 3px var(--shadow);
+  transition: transform 0.15s ease;
+}
+#radar-scrubber::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+#radar-scrubber::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--border-primary);
+}
+#radar-scrubber::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--bg-secondary);
+  border-radius: 50%;
+  background: var(--text-accent);
+  box-shadow: 0 1px 3px var(--shadow);
+}
+#radar-scrubber:focus-visible {
+  outline: 2px solid var(--text-accent);
+  outline-offset: 4px;
+}
+#radar-timestamp {
+  font-variant-numeric: tabular-nums;
+  min-width: 4.5em;
+  text-align: right;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--text-accent);
+}
 
 /* Tablet/phone: stack; radar full width, AQ back to a 2-col grid. */
 @media (max-width: 900px) {
@@ -2026,5 +2122,5 @@ html[data-theme="light"] .theme-toggle::before {
 @media (max-width: 480px) {
   #radar-controls { flex-wrap: wrap; }
   #radar-controls button { min-height: 44px; }   /* touch target */
-  #radar-scrubber { flex-basis: 100%; height: 28px; }
+  #radar-scrubber { flex-basis: 100%; }
 }

--- a/internal/controllers/restserver/assets/js/weather-radar.js
+++ b/internal/controllers/restserver/assets/js/weather-radar.js
@@ -1,0 +1,216 @@
+// Live weather radar for the station website. Reuses the Graywolf maps service
+// (https://maps.nw5w.com): Americana basemap + per-frame NEXRAD vector contours.
+//
+// The pure helpers below are dual-exported for node --test; the MapLibre glue
+// runs only in the browser.
+
+const DBZ_BANDS = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75];
+const DBZ_COLORS = {
+  5: '#c5f0f7', 10: '#a8e6f0', 15: '#88ddee', 20: '#00a3e0', 25: '#0077aa',
+  30: '#005588', 35: '#ffee00', 40: '#ffaa00', 45: '#ff4400', 50: '#c10000',
+  55: '#ffaaff', 60: '#ff77ff', 65: '#ffffff', 70: '#ffffff', 75: '#00ff00',
+};
+
+// MapLibre `step` expression: polygon `dbz` -> NWS/RainViewer ramp.
+function buildDbzFillColor() {
+  const expr = ['step', ['get', 'dbz'], DBZ_COLORS[DBZ_BANDS[0]]];
+  for (let i = 1; i < DBZ_BANDS.length; i++) expr.push(DBZ_BANDS[i], DBZ_COLORS[DBZ_BANDS[i]]);
+  return expr;
+}
+
+// Zoom so a `widthPx`-wide map spans `miles` at latitude `latDeg`.
+// Web-Mercator: meters/px = 156543.03 * cos(lat) / 2^z.
+function zoomForWidthMiles(miles, latDeg, widthPx) {
+  const meters = miles * 1609.344;
+  const lat = (latDeg * Math.PI) / 180;
+  const z = Math.log2((156543.03 * Math.cos(lat) * widthPx) / meters);
+  return Math.max(3, Math.min(z, 11));
+}
+
+// Radar manifest -> oldest-first [{ts, iso}]. Manifest `frames` is newest-first.
+function parseManifestFrames(json) {
+  if (!json || typeof json !== 'object') return [];
+  if (json.schema_version !== 1 || !Array.isArray(json.frames)) return [];
+  const frames = [];
+  for (const f of json.frames) {
+    if (!f || typeof f.ts !== 'number' || typeof f.iso !== 'string') continue;
+    frames.push({ ts: f.ts, iso: f.iso });
+  }
+  frames.reverse();
+  return frames;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { DBZ_BANDS, DBZ_COLORS, buildDbzFillColor, zoomForWidthMiles, parseManifestFrames };
+}
+
+// ---- Browser glue (skipped under node --test) -----------------------------
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  const TILE_HOST = 'maps.nw5w.com';
+  const STYLE_URL = `https://${TILE_HOST}/style/americana-roboto/style.json`;
+  const MANIFEST_URL = `https://${TILE_HOST}/radar/manifest.json`;
+  const FRAME_MS = 500;        // per-frame dwell
+  const HOLD_MS = 1500;        // longer hold on the newest frame
+  const POLL_MS = 60000;       // manifest refresh
+  const DESKTOP_MAX_FRAMES = 36;
+  const MOBILE_MAX_FRAMES = 12;
+
+  function initRadar() {
+    const cfgEl = document.getElementById('radar-config');
+    const mapEl = document.getElementById('radar-map');
+    if (!cfgEl || !mapEl || !window.maplibregl) return;
+    const cfg = JSON.parse(cfgEl.textContent);
+    const isTouch = window.matchMedia('(pointer: coarse)').matches;
+    const maxFrames = isTouch ? MOBILE_MAX_FRAMES : DESKTOP_MAX_FRAMES;
+
+    const tokenParam = (url) => {
+      const sep = url.includes('?') ? '&' : '?';
+      return `${url}${sep}t=${encodeURIComponent(cfg.token)}`;
+    };
+
+    const map = new maplibregl.Map({
+      container: 'radar-map',
+      style: STYLE_URL,
+      center: [cfg.lon, cfg.lat],
+      zoom: zoomForWidthMiles(cfg.widthMiles || 200, cfg.lat, mapEl.clientWidth || 800),
+      attributionControl: { compact: true },
+      cooperativeGestures: isTouch,
+      transformRequest: (url) => {
+        if (url.startsWith(`https://${TILE_HOST}/`) && !url.startsWith(`https://${TILE_HOST}/style/`)) {
+          return { url: tokenParam(url) };
+        }
+        return { url };
+      },
+    });
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+    map.addControl(new maplibregl.ScaleControl({ unit: 'imperial' }), 'bottom-left');
+
+    // Keep ~200mi width across resizes/orientation.
+    let resizeTimer = null;
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        map.setZoom(zoomForWidthMiles(cfg.widthMiles || 200, cfg.lat, mapEl.clientWidth || 800));
+      }, 200);
+    });
+
+    map.on('load', () => {
+      new maplibregl.Marker().setLngLat([cfg.lon, cfg.lat]).addTo(map);
+      startRadar(map, tokenParam, maxFrames, !isTouch);
+    });
+    // Single-tile fetch errors are benign; only log.
+    map.on('error', (e) => console.warn('[radar]', e && e.error ? e.error.message : e));
+  }
+
+  function startRadar(map, tokenParam, maxFrames, autoplay) {
+    const sourceId = (ts) => `radar-${ts}`;
+    const layerId = (ts) => `radar-fill-${ts}`;
+    const mounted = new Set();
+    let frames = [];        // oldest-first [{ts, iso}]
+    let index = 0;
+    let curTs = null;
+    let playing = false;
+    let timer = null;
+    const fillColor = buildDbzFillColor();
+
+    const firstSymbolId = () => (map.getStyle().layers.find((l) => l.type === 'symbol') || {}).id;
+
+    function ensureFrame(ts, visible) {
+      if (!map.getSource(sourceId(ts))) {
+        map.addSource(sourceId(ts), {
+          type: 'vector', minzoom: 3, maxzoom: 8,
+          tiles: [tokenParam(`https://maps.nw5w.com/radar/${ts}/{z}/{x}/{y}.pbf`)],
+          attribution: 'NEXRAD via NWS / Iowa State Mesonet',
+        });
+      }
+      if (!map.getLayer(layerId(ts))) {
+        map.addLayer({
+          id: layerId(ts), type: 'fill', source: sourceId(ts), 'source-layer': 'radar',
+          paint: { 'fill-color': fillColor, 'fill-antialias': false, 'fill-opacity': visible ? 0.75 : 0 },
+        }, firstSymbolId());
+      }
+      mounted.add(ts);
+    }
+
+    function removeFrame(ts) {
+      if (map.getLayer(layerId(ts))) map.removeLayer(layerId(ts));
+      if (map.getSource(sourceId(ts))) map.removeSource(sourceId(ts));
+      mounted.delete(ts);
+    }
+
+    function showFrame(ts) {
+      if (ts === curTs) return;
+      const prev = curTs;
+      curTs = ts;
+      ensureFrame(ts, true);
+      if (prev != null && map.getLayer(layerId(prev))) map.setPaintProperty(layerId(prev), 'fill-opacity', 0);
+      if (map.getLayer(layerId(ts))) map.setPaintProperty(layerId(ts), 'fill-opacity', 0.75);
+      updateUI();
+    }
+
+    function scheduleNext() {
+      clearTimeout(timer);
+      if (!playing || frames.length <= 1) return;
+      const atNewest = index >= frames.length - 1;
+      timer = setTimeout(() => {
+        index = (index + 1) % frames.length;
+        showFrame(frames[index].ts);
+        scheduleNext();
+      }, atNewest ? HOLD_MS : FRAME_MS);
+    }
+
+    function play() { if (frames.length > 1) { playing = true; scheduleNext(); updateUI(); } }
+    function pause() { playing = false; clearTimeout(timer); updateUI(); }
+    function reset() { pause(); index = frames.length - 1; if (frames[index]) showFrame(frames[index].ts); }
+    function seek(i) { pause(); index = Math.max(0, Math.min(i, frames.length - 1)); if (frames[index]) showFrame(frames[index].ts); }
+
+    async function poll() {
+      try {
+        const res = await fetch(tokenParam(MANIFEST_URL), { cache: 'no-store' });
+        if (!res.ok) return;
+        let next = parseManifestFrames(await res.json());
+        if (next.length > maxFrames) next = next.slice(next.length - maxFrames);
+        if (!next.length) return;
+        const keep = new Set(next.map((f) => f.ts));
+        for (const ts of [...mounted]) if (!keep.has(ts) && ts !== curTs) removeFrame(ts);
+        next.forEach((f) => ensureFrame(f.ts, false));
+        frames = next;
+        if (curTs == null || !keep.has(curTs)) { index = frames.length - 1; showFrame(frames[index].ts); }
+        else { index = frames.findIndex((f) => f.ts === curTs); }
+        updateUI();
+      } catch (e) { console.warn('[radar] manifest poll failed', e); }
+    }
+
+    // ---- controls ----
+    const btnPlay = document.getElementById('radar-play');
+    const btnReset = document.getElementById('radar-reset');
+    const slider = document.getElementById('radar-scrubber');
+    const tsLabel = document.getElementById('radar-timestamp');
+    if (btnPlay) btnPlay.addEventListener('click', () => (playing ? pause() : play()));
+    if (btnReset) btnReset.addEventListener('click', reset);
+    if (slider) slider.addEventListener('input', (e) => seek(Number(e.target.value)));
+
+    function updateUI() {
+      if (btnPlay) btnPlay.textContent = playing ? 'Pause' : 'Play';
+      if (slider) { slider.max = String(Math.max(0, frames.length - 1)); slider.value = String(index); }
+      if (tsLabel && frames[index]) {
+        tsLabel.textContent = new Date(frames[index].ts * 1000)
+          .toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+      }
+    }
+
+    poll().then(() => { if (autoplay) play(); });
+    setInterval(poll, POLL_MS);
+  }
+
+  // Lazy init: build the map only when the section scrolls into view.
+  document.addEventListener('DOMContentLoaded', () => {
+    const section = document.getElementById('radar-section');
+    if (!section) return;
+    if (!('IntersectionObserver' in window)) { initRadar(); return; }
+    const io = new IntersectionObserver((entries, obs) => {
+      if (entries.some((e) => e.isIntersecting)) { obs.disconnect(); initRadar(); }
+    }, { rootMargin: '200px' });
+    io.observe(section);
+  });
+}

--- a/internal/controllers/restserver/assets/js/weather-radar.js
+++ b/internal/controllers/restserver/assets/js/weather-radar.js
@@ -95,6 +95,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     });
 
     map.on('load', () => {
+      mapEl.classList.remove('is-loading');
       new maplibregl.Marker().setLngLat([cfg.lon, cfg.lat]).addTo(map);
       startRadar(map, tokenParam, maxFrames, !isTouch);
     });
@@ -191,7 +192,10 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     if (slider) slider.addEventListener('input', (e) => seek(Number(e.target.value)));
 
     function updateUI() {
-      if (btnPlay) btnPlay.textContent = playing ? 'Pause' : 'Play';
+      if (btnPlay) {
+        btnPlay.textContent = playing ? 'Pause' : 'Play';
+        btnPlay.setAttribute('aria-pressed', String(playing));
+      }
       if (slider) { slider.max = String(Math.max(0, frames.length - 1)); slider.value = String(index); }
       if (tsLabel && frames[index]) {
         tsLabel.textContent = new Date(frames[index].ts * 1000)

--- a/internal/controllers/restserver/assets/js/weather-radar.test.js
+++ b/internal/controllers/restserver/assets/js/weather-radar.test.js
@@ -1,0 +1,35 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { zoomForWidthMiles, buildDbzFillColor, parseManifestFrames } = require('./weather-radar.js');
+
+test('zoomForWidthMiles ~200mi at 40N lands around z7-8', () => {
+  const z = zoomForWidthMiles(200, 40.5, 800);
+  assert.ok(z > 6.5 && z < 8.5, `z=${z}`);
+});
+
+test('zoomForWidthMiles clamps to [3,11]', () => {
+  assert.strictEqual(zoomForWidthMiles(20000, 0, 800), 3);
+  assert.strictEqual(zoomForWidthMiles(0.001, 0, 800), 11);
+});
+
+test('buildDbzFillColor is a step expression keyed on dbz', () => {
+  const e = buildDbzFillColor();
+  assert.strictEqual(e[0], 'step');
+  assert.deepStrictEqual(e[1], ['get', 'dbz']);
+  assert.strictEqual(e[2], '#c5f0f7');          // base = lowest band color
+  assert.strictEqual(e[e.length - 2], 75);       // last stop input
+  assert.strictEqual(e[e.length - 1], '#00ff00');// last stop color
+});
+
+test('parseManifestFrames reverses newest-first to oldest-first', () => {
+  const frames = parseManifestFrames({
+    schema_version: 1,
+    frames: [{ ts: 200, iso: 'b' }, { ts: 100, iso: 'a' }],
+  });
+  assert.deepStrictEqual(frames.map(f => f.ts), [100, 200]);
+});
+
+test('parseManifestFrames returns [] for a bad manifest', () => {
+  assert.deepStrictEqual(parseManifestFrames({ schema_version: 2 }), []);
+  assert.deepStrictEqual(parseManifestFrames(null), []);
+});

--- a/internal/controllers/restserver/assets/weather-station.html.tmpl
+++ b/internal/controllers/restserver/assets/weather-station.html.tmpl
@@ -312,7 +312,7 @@
         {{ if .RadarEnabled }}
         <section id="radar-section" class="radar-block">
           <div class="group-title">LIVE RADAR</div>
-          <div id="radar-map"></div>
+          <div id="radar-map" class="is-loading"></div>
           <div id="radar-controls">
             <button type="button" id="radar-play">Play</button>
             <button type="button" id="radar-reset">Reset</button>

--- a/internal/controllers/restserver/assets/weather-station.html.tmpl
+++ b/internal/controllers/restserver/assets/weather-station.html.tmpl
@@ -15,7 +15,14 @@
   <link href="css/normalize.css" rel="stylesheet" type="text/css">
   <link href="css/fonts.css" rel="stylesheet" type="text/css">
   <link href="css/weather.css" rel="stylesheet" type="text/css">
-  
+
+  {{ if .RadarEnabled }}
+  <!-- Live radar: MapLibre GL JS (CDN) + the radar module -->
+  <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" crossorigin="anonymous">
+  <script defer src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js" crossorigin="anonymous"></script>
+  <script defer src="js/weather-radar.js"></script>
+  {{ end }}
+
   <!-- Preconnect to Highcharts CDN for faster loading -->
   <link rel="preconnect" href="https://code.highcharts.com">
   
@@ -244,10 +251,11 @@
       </div>
       {{ end }}
       
-      <!-- Air Quality Section -->
-      {{ if .AirQualityEnabled }}
-      <div class="metric-groups">
-        <div class="metric-group span-full">
+      <!-- Radar + Air Quality row (each renders independently; paired side-by-side on desktop) -->
+      {{ if or .RadarEnabled .AirQualityEnabled }}
+      <div class="radar-aq-row">
+        {{ if .AirQualityEnabled }}
+        <div class="metric-group span-full aq-block">
           <div class="group-title">AIR QUALITY</div>
           <div class="group-metrics air-quality-metrics">
             <div class="metric-item">
@@ -300,6 +308,22 @@
             </div>
           </div>
         </div>
+        {{ end }}
+        {{ if .RadarEnabled }}
+        <section id="radar-section" class="radar-block">
+          <div class="group-title">LIVE RADAR</div>
+          <div id="radar-map"></div>
+          <div id="radar-controls">
+            <button type="button" id="radar-play">Play</button>
+            <button type="button" id="radar-reset">Reset</button>
+            <input type="range" id="radar-scrubber" min="0" max="0" value="0" aria-label="Radar frame">
+            <span id="radar-timestamp">--</span>
+          </div>
+          <script id="radar-config" type="application/json">
+            {"lat": {{ .Latitude }}, "lon": {{ .Longitude }}, "token": "{{ .RadarToken }}", "widthMiles": 200}
+          </script>
+        </section>
+        {{ end }}
       </div>
       {{ end }}
       

--- a/internal/controllers/restserver/handlers.go
+++ b/internal/controllers/restserver/handlers.go
@@ -888,6 +888,10 @@ func (h *Handlers) ServeWeatherWebsiteTemplate(w http.ResponseWriter, req *http.
 		Version             string
 		AerisWeatherEnabled bool
 		AppleAppID          string
+		Latitude            float64
+		Longitude           float64
+		RadarEnabled        bool
+		RadarToken          string
 	}{
 		StationName:         website.Name,
 		StationID:           primaryDevice.ID,
@@ -903,6 +907,10 @@ func (h *Handlers) ServeWeatherWebsiteTemplate(w http.ResponseWriter, req *http.
 		Version:             constants.Version,
 		AerisWeatherEnabled: primaryDevice.AerisEnabled,
 		AppleAppID:          website.AppleAppID,
+		Latitude:            primaryDevice.Latitude,
+		Longitude:           primaryDevice.Longitude,
+		RadarEnabled:        website.RadarEnabled,
+		RadarToken:          website.RadarToken,
 	}
 
 	w.Header().Set("Content-Type", "text/html")

--- a/internal/controllers/restserver/handlers.go
+++ b/internal/controllers/restserver/handlers.go
@@ -18,8 +18,8 @@ import (
 	"github.com/chrissnell/remoteweather/internal/log"
 	"github.com/chrissnell/remoteweather/internal/types"
 	"github.com/chrissnell/remoteweather/pkg/config"
-	"github.com/chrissnell/remoteweather/pkg/responseformat"
 	"github.com/chrissnell/remoteweather/pkg/lunar"
+	"github.com/chrissnell/remoteweather/pkg/responseformat"
 	"github.com/chrissnell/remoteweather/pkg/solar"
 	"github.com/gorilla/mux"
 	"gorm.io/gorm"
@@ -1466,4 +1466,3 @@ func (h *Handlers) GetAlerts(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 }
-

--- a/migrations/config/025_add_radar_fields.down.sql
+++ b/migrations/config/025_add_radar_fields.down.sql
@@ -1,0 +1,38 @@
+-- Remove live weather radar support. SQLite has no DROP COLUMN, so rebuild the
+-- table without the radar columns, preserving everything migrations 002-021 left.
+CREATE TABLE weather_websites_temp (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    config_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    device_id INTEGER,
+    hostname TEXT,
+    page_title TEXT,
+    about_station_html TEXT,
+    snow_enabled BOOLEAN DEFAULT FALSE,
+    snow_device_name TEXT,
+    air_quality_enabled BOOLEAN DEFAULT FALSE,
+    air_quality_device_name TEXT,
+    tls_cert_path TEXT,
+    tls_key_path TEXT,
+    is_portal BOOLEAN DEFAULT FALSE,
+    apple_app_id TEXT DEFAULT '6755874087',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (config_id) REFERENCES configs(id) ON DELETE CASCADE,
+    FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE SET NULL,
+    UNIQUE(config_id, name)
+);
+INSERT INTO weather_websites_temp (
+    id, config_id, name, device_id, hostname, page_title, about_station_html,
+    snow_enabled, snow_device_name, air_quality_enabled, air_quality_device_name,
+    tls_cert_path, tls_key_path, is_portal, apple_app_id, created_at, updated_at
+)
+SELECT
+    id, config_id, name, device_id, hostname, page_title, about_station_html,
+    snow_enabled, snow_device_name, air_quality_enabled, air_quality_device_name,
+    tls_cert_path, tls_key_path, is_portal, apple_app_id, created_at, updated_at
+FROM weather_websites;
+DROP TABLE weather_websites;
+ALTER TABLE weather_websites_temp RENAME TO weather_websites;
+CREATE INDEX idx_weather_websites_config_id ON weather_websites(config_id);
+CREATE INDEX idx_weather_websites_device_id ON weather_websites(device_id);

--- a/migrations/config/025_add_radar_fields.up.sql
+++ b/migrations/config/025_add_radar_fields.up.sql
@@ -1,0 +1,4 @@
+-- Add live weather radar support to weather websites.
+ALTER TABLE weather_websites ADD COLUMN radar_enabled BOOLEAN DEFAULT FALSE;
+ALTER TABLE weather_websites ADD COLUMN radar_token TEXT DEFAULT '';
+ALTER TABLE weather_websites ADD COLUMN radar_registered_at INTEGER;

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -41,6 +41,8 @@ type ConfigProvider interface {
 	AddWeatherWebsite(website *WeatherWebsiteData) error
 	UpdateWeatherWebsite(id int, website *WeatherWebsiteData) error
 	DeleteWeatherWebsite(id int) error
+	SetWebsiteRadarRegistration(id int, token string, registeredAt int64) error
+	ClearWebsiteRadarRegistration(id int) error
 
 	// Sun times management (pre-calculated sunrise/sunset)
 	GetSunTimes(stationName string, dayOfYear int) (sunrise, sunset int, err error)
@@ -392,6 +394,9 @@ type WeatherWebsiteData struct {
 	TLSKeyPath           string `json:"tls_key_path,omitempty"`  // Optional per-site TLS key (overrides server default)
 	IsPortal             bool   `json:"is_portal,omitempty"`     // Whether this website is a weather management portal
 	AppleAppID           string `json:"apple_app_id,omitempty"`  // Numeric App Store ID for iOS Smart Banner
+	RadarEnabled         bool   `json:"radar_enabled,omitempty"`
+	RadarToken           string `json:"radar_token,omitempty"`          // set only by registration
+	RadarRegisteredAt    *int64 `json:"radar_registered_at,omitempty"`  // unix; nil until registered
 }
 
 type ManagementAPIData struct {
@@ -711,6 +716,24 @@ func (c *CachedConfigProvider) UpdateWeatherWebsite(id int, website *WeatherWebs
 // DeleteWeatherWebsite removes a weather website and invalidates cache
 func (c *CachedConfigProvider) DeleteWeatherWebsite(id int) error {
 	err := c.provider.DeleteWeatherWebsite(id)
+	if err == nil {
+		c.InvalidateCache()
+	}
+	return err
+}
+
+// SetWebsiteRadarRegistration enables radar and invalidates cache
+func (c *CachedConfigProvider) SetWebsiteRadarRegistration(id int, token string, registeredAt int64) error {
+	err := c.provider.SetWebsiteRadarRegistration(id, token, registeredAt)
+	if err == nil {
+		c.InvalidateCache()
+	}
+	return err
+}
+
+// ClearWebsiteRadarRegistration disables radar and invalidates cache
+func (c *CachedConfigProvider) ClearWebsiteRadarRegistration(id int) error {
+	err := c.provider.ClearWebsiteRadarRegistration(id)
 	if err == nil {
 		c.InvalidateCache()
 	}

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -352,12 +352,12 @@ type APRSData struct {
 // The snow cache controller runs background calculations for snow accumulation
 // using PELT change point detection for 72h and seasonal totals
 type SnowCacheData struct {
-	StationName     string  `json:"station_name,omitempty"`      // Name of the weather station with snow depth sensor
-	BaseDistance    float64 `json:"base_distance,omitempty"`     // Base snow distance calibration value (mm)
-	SmoothingWindow int     `json:"smoothing_window,omitempty"`  // Hours of data for median filtering (default: 5)
-	Penalty         float64 `json:"penalty,omitempty"`           // PELT penalty parameter (default: 3.0)
-	MinAccumulation float64 `json:"min_accumulation,omitempty"`  // Minimum accumulation threshold in mm (default: 5.0)
-	MinSegmentSize  int     `json:"min_segment_size,omitempty"`  // Minimum segment size for PELT (default: 2)
+	StationName     string  `json:"station_name,omitempty"`     // Name of the weather station with snow depth sensor
+	BaseDistance    float64 `json:"base_distance,omitempty"`    // Base snow distance calibration value (mm)
+	SmoothingWindow int     `json:"smoothing_window,omitempty"` // Hours of data for median filtering (default: 5)
+	Penalty         float64 `json:"penalty,omitempty"`          // PELT penalty parameter (default: 3.0)
+	MinAccumulation float64 `json:"min_accumulation,omitempty"` // Minimum accumulation threshold in mm (default: 5.0)
+	MinSegmentSize  int     `json:"min_segment_size,omitempty"` // Minimum segment size for PELT (default: 2)
 }
 
 // RESTServerData holds configuration for the REST server
@@ -395,8 +395,8 @@ type WeatherWebsiteData struct {
 	IsPortal             bool   `json:"is_portal,omitempty"`     // Whether this website is a weather management portal
 	AppleAppID           string `json:"apple_app_id,omitempty"`  // Numeric App Store ID for iOS Smart Banner
 	RadarEnabled         bool   `json:"radar_enabled,omitempty"`
-	RadarToken           string `json:"radar_token,omitempty"`          // set only by registration
-	RadarRegisteredAt    *int64 `json:"radar_registered_at,omitempty"`  // unix; nil until registered
+	RadarToken           string `json:"radar_token,omitempty"`         // set only by registration
+	RadarRegisteredAt    *int64 `json:"radar_registered_at,omitempty"` // unix; nil until registered
 }
 
 type ManagementAPIData struct {

--- a/pkg/config/provider_radar_test.go
+++ b/pkg/config/provider_radar_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newTestProvider(t *testing.T) *SQLiteProvider {
+	t.Helper()
+	p, err := NewSQLiteProvider(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteProvider: %v", err)
+	}
+	t.Cleanup(func() { p.Close() })
+	return p
+}
+
+func TestWeatherWebsiteRadarDefaults(t *testing.T) {
+	p := newTestProvider(t)
+	w := &WeatherWebsiteData{Name: "Radar Test", Hostname: "radar.example.com", IsPortal: true}
+	if err := p.AddWeatherWebsite(w); err != nil {
+		t.Fatalf("AddWeatherWebsite: %v", err)
+	}
+	got, err := p.GetWeatherWebsite(w.ID)
+	if err != nil {
+		t.Fatalf("GetWeatherWebsite: %v", err)
+	}
+	if got.RadarEnabled {
+		t.Errorf("RadarEnabled = true, want false (default)")
+	}
+	if got.RadarToken != "" {
+		t.Errorf("RadarToken = %q, want empty", got.RadarToken)
+	}
+	if got.RadarRegisteredAt != nil {
+		t.Errorf("RadarRegisteredAt = %v, want nil", got.RadarRegisteredAt)
+	}
+}
+
+func TestWeatherWebsiteRadarRegistration(t *testing.T) {
+	p := newTestProvider(t)
+	w := &WeatherWebsiteData{Name: "Reg Test", Hostname: "reg.example.com", IsPortal: true}
+	if err := p.AddWeatherWebsite(w); err != nil {
+		t.Fatalf("AddWeatherWebsite: %v", err)
+	}
+
+	if err := p.SetWebsiteRadarRegistration(w.ID, "tok-123", 1700000000); err != nil {
+		t.Fatalf("SetWebsiteRadarRegistration: %v", err)
+	}
+	got, _ := p.GetWeatherWebsite(w.ID)
+	if !got.RadarEnabled || got.RadarToken != "tok-123" ||
+		got.RadarRegisteredAt == nil || *got.RadarRegisteredAt != 1700000000 {
+		t.Fatalf("after register: %+v", got)
+	}
+
+	// A generic form update must NOT clobber the radar registration.
+	got.Name = "Renamed"
+	if err := p.UpdateWeatherWebsite(w.ID, got); err != nil {
+		t.Fatalf("UpdateWeatherWebsite: %v", err)
+	}
+	after, _ := p.GetWeatherWebsite(w.ID)
+	if !after.RadarEnabled || after.RadarToken != "tok-123" {
+		t.Fatalf("form update clobbered radar: %+v", after)
+	}
+
+	if err := p.ClearWebsiteRadarRegistration(w.ID); err != nil {
+		t.Fatalf("ClearWebsiteRadarRegistration: %v", err)
+	}
+	cleared, _ := p.GetWeatherWebsite(w.ID)
+	if cleared.RadarEnabled || cleared.RadarToken != "" || cleared.RadarRegisteredAt != nil {
+		t.Fatalf("after clear: %+v", cleared)
+	}
+}

--- a/pkg/config/provider_sqlite.go
+++ b/pkg/config/provider_sqlite.go
@@ -263,6 +263,10 @@ CREATE TABLE weather_websites (
     tls_cert_path TEXT,
     tls_key_path TEXT,
     is_portal BOOLEAN DEFAULT FALSE,
+    apple_app_id TEXT DEFAULT '6755874087',
+    radar_enabled BOOLEAN DEFAULT FALSE,
+    radar_token TEXT DEFAULT '',
+    radar_registered_at INTEGER,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (config_id) REFERENCES configs(id) ON DELETE CASCADE,
@@ -1738,7 +1742,8 @@ func (s *SQLiteProvider) GetWeatherWebsites() ([]WeatherWebsiteData, error) {
 		SELECT w.id, w.name, w.device_id, d.name as device_name, w.hostname, w.page_title,
 		       w.about_station_html, w.snow_enabled, w.snow_device_name,
 		       w.air_quality_enabled, w.air_quality_device_name,
-		       w.tls_cert_path, w.tls_key_path, w.is_portal, w.apple_app_id
+		       w.tls_cert_path, w.tls_key_path, w.is_portal, w.apple_app_id,
+		       w.radar_enabled, w.radar_token, w.radar_registered_at
 		FROM weather_websites w
 		LEFT JOIN devices d ON w.device_id = d.id
 		WHERE w.config_id = (SELECT id FROM configs WHERE name = 'default')
@@ -1759,6 +1764,9 @@ func (s *SQLiteProvider) GetWeatherWebsites() ([]WeatherWebsiteData, error) {
 		var airQualityEnabled sql.NullBool
 		var airQualityDeviceName sql.NullString
 		var tlsCertPath, tlsKeyPath, appleAppID sql.NullString
+		var radarEnabled sql.NullBool
+		var radarToken sql.NullString
+		var radarRegisteredAt sql.NullInt64
 
 		err := rows.Scan(
 			&website.ID,
@@ -1776,6 +1784,9 @@ func (s *SQLiteProvider) GetWeatherWebsites() ([]WeatherWebsiteData, error) {
 			&tlsKeyPath,
 			&website.IsPortal,
 			&appleAppID,
+			&radarEnabled,
+			&radarToken,
+			&radarRegisteredAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan website row: %w", err)
@@ -1801,6 +1812,14 @@ func (s *SQLiteProvider) GetWeatherWebsites() ([]WeatherWebsiteData, error) {
 		website.TLSCertPath = tlsCertPath.String
 		website.TLSKeyPath = tlsKeyPath.String
 		website.AppleAppID = appleAppID.String
+		if radarEnabled.Valid {
+			website.RadarEnabled = radarEnabled.Bool
+		}
+		website.RadarToken = radarToken.String
+		if radarRegisteredAt.Valid {
+			v := radarRegisteredAt.Int64
+			website.RadarRegisteredAt = &v
+		}
 
 		websites = append(websites, website)
 	}
@@ -1814,7 +1833,8 @@ func (s *SQLiteProvider) GetWeatherWebsite(id int) (*WeatherWebsiteData, error) 
 		SELECT w.id, w.name, w.device_id, d.name as device_name, w.hostname, w.page_title,
 		       w.about_station_html, w.snow_enabled, w.snow_device_name,
 		       w.air_quality_enabled, w.air_quality_device_name,
-		       w.tls_cert_path, w.tls_key_path, w.is_portal, w.apple_app_id
+		       w.tls_cert_path, w.tls_key_path, w.is_portal, w.apple_app_id,
+		       w.radar_enabled, w.radar_token, w.radar_registered_at
 		FROM weather_websites w
 		LEFT JOIN devices d ON w.device_id = d.id
 		WHERE w.id = ? AND w.config_id = (SELECT id FROM configs WHERE name = 'default')`
@@ -1826,6 +1846,9 @@ func (s *SQLiteProvider) GetWeatherWebsite(id int) (*WeatherWebsiteData, error) 
 	var airQualityEnabled sql.NullBool
 	var airQualityDeviceName sql.NullString
 	var tlsCertPath, tlsKeyPath, appleAppID sql.NullString
+	var radarEnabled sql.NullBool
+	var radarToken sql.NullString
+	var radarRegisteredAt sql.NullInt64
 
 	err := s.db.QueryRow(query, id).Scan(
 		&website.ID,
@@ -1843,6 +1866,9 @@ func (s *SQLiteProvider) GetWeatherWebsite(id int) (*WeatherWebsiteData, error) 
 		&tlsKeyPath,
 		&website.IsPortal,
 		&appleAppID,
+		&radarEnabled,
+		&radarToken,
+		&radarRegisteredAt,
 	)
 
 	if err != nil {
@@ -1872,6 +1898,14 @@ func (s *SQLiteProvider) GetWeatherWebsite(id int) (*WeatherWebsiteData, error) 
 	website.TLSCertPath = tlsCertPath.String
 	website.TLSKeyPath = tlsKeyPath.String
 	website.AppleAppID = appleAppID.String
+	if radarEnabled.Valid {
+		website.RadarEnabled = radarEnabled.Bool
+	}
+	website.RadarToken = radarToken.String
+	if radarRegisteredAt.Valid {
+		v := radarRegisteredAt.Int64
+		website.RadarRegisteredAt = &v
+	}
 
 	return &website, nil
 }
@@ -1999,6 +2033,40 @@ func (s *SQLiteProvider) UpdateWeatherWebsite(id int, website *WeatherWebsiteDat
 
 	website.ID = id
 	return tx.Commit()
+}
+
+// SetWebsiteRadarRegistration enables radar for a website and stores its token.
+// Radar columns are written ONLY here (and ClearWebsiteRadarRegistration) so the
+// generic website UPDATE can never clobber the token.
+func (s *SQLiteProvider) SetWebsiteRadarRegistration(id int, token string, registeredAt int64) error {
+	res, err := s.db.Exec(
+		`UPDATE weather_websites SET radar_enabled = 1, radar_token = ?, radar_registered_at = ? WHERE id = ?`,
+		token, registeredAt, id,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set radar registration: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("weather website %d not found", id)
+	}
+	return nil
+}
+
+// ClearWebsiteRadarRegistration disables radar and removes the stored token.
+func (s *SQLiteProvider) ClearWebsiteRadarRegistration(id int) error {
+	res, err := s.db.Exec(
+		`UPDATE weather_websites SET radar_enabled = 0, radar_token = '', radar_registered_at = NULL WHERE id = ?`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to clear radar registration: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("weather website %d not found", id)
+	}
+	return nil
 }
 
 // DeleteWeatherWebsite removes a weather website from the configuration

--- a/pkg/config/provider_sqlite.go
+++ b/pkg/config/provider_sqlite.go
@@ -288,6 +288,7 @@ CREATE INDEX idx_storage_configs_health_last_check ON storage_configs(health_las
 CREATE INDEX idx_controller_configs_config_id ON controller_configs(config_id);
 CREATE INDEX idx_controller_configs_type ON controller_configs(config_id, controller_type);
 CREATE INDEX idx_weather_websites_config_id ON weather_websites(config_id);
+CREATE INDEX idx_weather_websites_device_id ON weather_websites(device_id);
 
 -- Remote stations table for gRPC remote station registrations
 CREATE TABLE IF NOT EXISTS remote_stations (


### PR DESCRIPTION
## Live Weather Radar (PR 2)

Adds an animated, self-service-registered live weather radar to the public station website, centered on the station with a ~200-mile viewport, reusing the Graywolf maps service. This is PR 2 of the design from GRA-97; depends on PR 1 (`graywolf-maps`, branch `feature/remoteweather-registration`) being deployed so `auth.nw5w.com/register/remoteweather` is live.

### What's included
- **Config** — per-website `radar_enabled` / `radar_token` / `radar_registered_at` (inline schema + migration `025`). Radar columns are written only by dedicated registration mutators, never the generic website UPDATE, so the website form can't clobber the token. Also backfills the previously-missing `apple_app_id` column into the inline schema so fresh databases build cleanly.
- **Registration** — outbound client to the Graywolf auth worker (hostname identifier + non-commercial agreement), `POST`/`DELETE /api/config/websites/{id}/radar/register` endpoints, and a management-console panel (terms + agree + Register/Disable, with an Enabled/Not-enabled status badge).
- **Public radar** — MapLibre GL JS embed using Graywolf's Americana basemap + per-frame NEXRAD vector contour tiles, with Play/Pause/Reset + a frame scrubber, lat/lon centering, cooperative gestures, lazy init, bounded mobile frame window, and no mobile autoplay. Pure helpers (dBZ palette, 200-mile zoom math, manifest parse) are unit-tested under `node --test`.
- **UI polish** — themed control buttons, a custom dark-theme range slider, framed map with a loading state, and a polished control bar, all reusing existing design tokens.

### Layout
Air Quality becomes a 1×6 column on the left with the radar to its right on desktop; both stack on mobile. Radar and Air Quality are fully independent (separate enable flags); the side-by-side pairing is CSS-only when both are present.

### Verification
`go build ./...` clean, `go test ./...` green (new `pkg/config` + `management` tests), `node --test weather-radar.test.js` 5/5, gofmt clean. The ported palette / tile path / manifest schema / `source-layer` were cross-checked against the live `graywolf` and `graywolf-maps` sources.
