### PR TITLE
Almanac: populate all extreme records via cache

### DIFF
--- a/internal/controllers/restserver/handlers.go
+++ b/internal/controllers/restserver/handlers.go
@@ -1273,11 +1273,13 @@ type AlmanacData struct {
 	DeepestSnow   *AlmanacRecord `json:"deepest_snow,omitempty"`
 	MaxSnowHour   *AlmanacRecord `json:"max_snow_hour,omitempty"`
 	MaxSnowDay    *AlmanacRecord `json:"max_snow_day,omitempty"`
+	HighSolar     *AlmanacRecord `json:"high_solar,omitempty"`
 	HighPM25      *AlmanacRecord `json:"high_pm25,omitempty"`
 	HighPM10In    *AlmanacRecord `json:"high_pm10_in,omitempty"`
 	HighCO2       *AlmanacRecord `json:"high_co2,omitempty"`
 	HighAQIPM25   *AlmanacRecord `json:"high_aqi_pm25,omitempty"`
-	// Note: HighSolar and HighAQIPM10 removed (too slow to query)
+	HighAQIPM10   *AlmanacRecord `json:"high_aqi_pm10,omitempty"`
+	HighAQIPM25In *AlmanacRecord `json:"high_aqi_pm25_in,omitempty"`
 }
 
 // AlmanacCacheRow represents a row from the almanac_cache table
@@ -1358,6 +1360,8 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 			almanac.LowBarometer = record
 		case "low_humidity":
 			almanac.LowHumidity = record
+		case "high_solar":
+			almanac.HighSolar = record
 		case "high_pm25":
 			almanac.HighPM25 = record
 		case "high_pm10_in":
@@ -1366,8 +1370,11 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 			almanac.HighCO2 = record
 		case "high_aqi_pm25":
 			almanac.HighAQIPM25 = record
+		case "high_aqi_pm10":
+			almanac.HighAQIPM10 = record
+		case "high_aqi_pm25_in":
+			almanac.HighAQIPM25In = record
 		}
-		// Note: high_solar and high_aqi_pm10 removed (too slow to compute)
 	}
 
 	// Snow metrics temporarily disabled due to performance issues

--- a/internal/storage/timescaledb/sql.go
+++ b/internal/storage/timescaledb/sql.go
@@ -2024,6 +2024,8 @@ CREATE INDEX IF NOT EXISTS weather_1d_bucket_stationname_idx ON weather_1d (stat
 CREATE INDEX IF NOT EXISTS weather_stationname_time_idx ON weather (stationname, time DESC);
 CREATE INDEX IF NOT EXISTS weather_time_stationname_idx ON weather (time DESC, stationname);
 CREATE INDEX IF NOT EXISTS weather_stationname_snowdistance_time_idx ON weather (stationname, time DESC) WHERE snowdistance IS NOT NULL AND snowdistance > 0;
+-- Solar peak index for the almanac high_solar query (the only almanac metric read from the raw weather table)
+CREATE INDEX IF NOT EXISTS weather_stationname_solarwatts_idx ON weather (stationname, solarwatts DESC) WHERE solarwatts IS NOT NULL AND solarwatts > 0;
 -- Snow indexes for aggregation tables (for almanac queries)
 CREATE INDEX IF NOT EXISTS weather_1h_stationname_snowdistance_bucket_idx ON weather_1h (stationname, bucket DESC) WHERE snowdistance IS NOT NULL AND snowdistance > 0;
 CREATE INDEX IF NOT EXISTS weather_1d_stationname_snowdistance_bucket_idx ON weather_1d (stationname, bucket DESC) WHERE snowdistance IS NOT NULL AND snowdistance > 0;`

--- a/migrations/weather/028_complete_almanac_metrics.down.sql
+++ b/migrations/weather/028_complete_almanac_metrics.down.sql
@@ -1,0 +1,102 @@
+-- Revert refresh_almanac_cache_single to the original (migration 005) behavior:
+-- the missing metrics are dropped and the two corrected metrics return to their
+-- former source columns.
+CREATE OR REPLACE FUNCTION refresh_almanac_cache_single(p_stationname TEXT)
+RETURNS void AS $$
+BEGIN
+    -- Delete existing data for this station
+    DELETE FROM almanac_cache WHERE stationname = p_stationname;
+
+    -- Highest temperature - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_temp', max_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_outtemp IS NOT NULL
+    ORDER BY max_outtemp DESC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest temperature - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_temp', min_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outtemp IS NOT NULL
+    ORDER BY min_outtemp ASC NULLS LAST
+    LIMIT 1;
+
+    -- Highest wind speed - use weather_1d for speed (note: winddir is circular_avg per day, not exact)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp, wind_dir)
+    SELECT p_stationname, 'high_wind_speed', max_windspeed, bucket, winddir
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_windspeed IS NOT NULL
+    ORDER BY max_windspeed DESC NULLS LAST
+    LIMIT 1;
+
+    -- Max rain in 1 hour
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_hour', period_rain, bucket
+    FROM weather_1h
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    -- Max rain in 1 day
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_day', period_rain, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest barometer - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_barometer', min_barometer, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_barometer > 0
+    ORDER BY min_barometer ASC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest humidity - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_humidity', min_outhumidity, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outhumidity > 0
+    ORDER BY min_outhumidity ASC NULLS LAST
+    LIMIT 1;
+
+    -- Highest PM2.5 - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25', max_pm25, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25 > 0
+    ORDER BY max_pm25 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest PM10 - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm10_in', max_pm25_in, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25_in > 0
+    ORDER BY max_pm25_in DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest CO2 - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_co2', max_co2, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_co2 > 0
+    ORDER BY max_co2 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest AQI PM2.5 - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_aqi_pm25', max_aqi_pm25_in::real, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_aqi_pm25_in > 0
+    ORDER BY max_aqi_pm25_in DESC NULLS LAST
+    LIMIT 1;
+
+END;
+$$ LANGUAGE plpgsql;
+
+-- Repopulate the cache with the reverted metric set.
+SELECT refresh_almanac_cache();

--- a/migrations/weather/028_complete_almanac_metrics.down.sql
+++ b/migrations/weather/028_complete_almanac_metrics.down.sql
@@ -100,3 +100,6 @@ $$ LANGUAGE plpgsql;
 
 -- Repopulate the cache with the reverted metric set.
 SELECT refresh_almanac_cache();
+
+-- Drop the solar lookup index (no longer needed once high_solar is gone).
+DROP INDEX IF EXISTS weather_stationname_solarwatts_idx;

--- a/migrations/weather/028_complete_almanac_metrics.up.sql
+++ b/migrations/weather/028_complete_almanac_metrics.up.sql
@@ -1,0 +1,139 @@
+-- Complete the almanac cache so every metric the UI renders is populated.
+--
+-- The original refresh_almanac_cache_single (migration 005) was missing three
+-- metrics that the frontend always displayed as "--" (high_solar, high_aqi_pm10,
+-- high_aqi_pm25_in) and mapped two others to the wrong source columns
+-- (high_pm10_in read indoor PM2.5, high_aqi_pm25 read the indoor AQI). This
+-- replaces the function so all extremes are pre-computed by the hourly job and
+-- read from almanac_cache on page load (no per-request queries against the
+-- weather table).
+CREATE OR REPLACE FUNCTION refresh_almanac_cache_single(p_stationname TEXT)
+RETURNS void AS $$
+BEGIN
+    -- Delete existing data for this station
+    DELETE FROM almanac_cache WHERE stationname = p_stationname;
+
+    -- Highest temperature - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_temp', max_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_outtemp IS NOT NULL
+    ORDER BY max_outtemp DESC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest temperature - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_temp', min_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outtemp IS NOT NULL
+    ORDER BY min_outtemp ASC NULLS LAST
+    LIMIT 1;
+
+    -- Highest wind speed - use weather_1d for speed (note: winddir is circular_avg per day, not exact)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp, wind_dir)
+    SELECT p_stationname, 'high_wind_speed', max_windspeed, bucket, winddir
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_windspeed IS NOT NULL
+    ORDER BY max_windspeed DESC NULLS LAST
+    LIMIT 1;
+
+    -- Max rain in 1 hour
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_hour', period_rain, bucket
+    FROM weather_1h
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    -- Max rain in 1 day
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_day', period_rain, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest barometer - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_barometer', min_barometer, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_barometer > 0
+    ORDER BY min_barometer ASC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest humidity - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_humidity', min_outhumidity, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outhumidity > 0
+    ORDER BY min_outhumidity ASC NULLS LAST
+    LIMIT 1;
+
+    -- Highest solar radiation - the continuous aggregates only keep a daily
+    -- average of solarwatts, so the all-time peak has to come from the raw
+    -- weather table. This is the only raw-table scan in the function and it
+    -- runs in the hourly background job, never on a page request.
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_solar', solarwatts, time
+    FROM weather
+    WHERE stationname = p_stationname AND solarwatts IS NOT NULL AND solarwatts > 0
+    ORDER BY solarwatts DESC
+    LIMIT 1;
+
+    -- Highest PM2.5 (outdoor) - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25', max_pm25, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25 > 0
+    ORDER BY max_pm25 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest PM10 - sourced from the AQIN sensor (the only PM10 reading we
+    -- record). Previously this read max_pm25_in (indoor PM2.5) by mistake.
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm10_in', max_pm10_in_aqin, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm10_in_aqin > 0
+    ORDER BY max_pm10_in_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest CO2 - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_co2', max_co2, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_co2 > 0
+    ORDER BY max_co2 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest AQI PM2.5 - the AQIN sensor's outdoor AQI, matching the live
+    -- display. Previously this read the indoor AQI (max_aqi_pm25_in).
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_aqi_pm25', max_aqi_pm25_aqin::real, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_aqi_pm25_aqin > 0
+    ORDER BY max_aqi_pm25_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest AQI PM10 (AQIN sensor)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_aqi_pm10', max_aqi_pm10_aqin::real, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_aqi_pm10_aqin > 0
+    ORDER BY max_aqi_pm10_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest indoor AQI PM2.5 (console sensor)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_aqi_pm25_in', max_aqi_pm25_in::real, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_aqi_pm25_in > 0
+    ORDER BY max_aqi_pm25_in DESC NULLS LAST
+    LIMIT 1;
+
+    -- Note: Snow metrics are calculated separately as they require base_distance parameter
+
+END;
+$$ LANGUAGE plpgsql;
+
+-- Repopulate the cache for every station with the corrected/expanded metrics.
+SELECT refresh_almanac_cache();

--- a/migrations/weather/028_complete_almanac_metrics.up.sql
+++ b/migrations/weather/028_complete_almanac_metrics.up.sql
@@ -7,6 +7,16 @@
 -- replaces the function so all extremes are pre-computed by the hourly job and
 -- read from almanac_cache on page load (no per-request queries against the
 -- weather table).
+
+-- Partial index so the high_solar lookup is an indexed top-1 scan instead of a
+-- full table scan. Mirrors the existing weather_stationname_snowdistance_time_idx
+-- pattern used for the snow almanac queries. The solar peak is the only metric
+-- sourced from the raw weather table (the continuous aggregates keep only a
+-- daily average of solarwatts), so this keeps the hourly refresh job cheap.
+CREATE INDEX IF NOT EXISTS weather_stationname_solarwatts_idx
+    ON weather (stationname, solarwatts DESC)
+    WHERE solarwatts IS NOT NULL AND solarwatts > 0;
+
 CREATE OR REPLACE FUNCTION refresh_almanac_cache_single(p_stationname TEXT)
 RETURNS void AS $$
 BEGIN


### PR DESCRIPTION
## Summary

The almanac page rendered several all-time extremes as a permanent `--` and mislabeled two others. This completes the cached metric set so every card the UI shows is populated, while keeping page loads cheap (they still read only the pre-computed `almanac_cache` table).

### What was broken
- **Highest Solar Radiation**, **Highest AQI PM10**, and **Highest Indoor AQI PM2.5** were never produced by the backend, so they always showed `--`.
- **Highest PM10** read indoor PM2.5 (`max_pm25_in`) instead of a PM10 column.
- **Highest AQI PM2.5** read the indoor AQI (`max_aqi_pm25_in`) instead of the outdoor AQIN AQI shown in the live display.

### Changes
- New migration `028_complete_almanac_metrics` rewrites the hourly `refresh_almanac_cache_single` job to:
  - add `high_solar`, `high_aqi_pm10`, `high_aqi_pm25_in`;
  - fix `high_pm10_in` → `max_pm10_in_aqin` and `high_aqi_pm25` → `max_aqi_pm25_aqin`;
  - repopulate the cache for all stations.
- `AlmanacData` gains the three new fields and `GetAlmanac` maps them.

### Efficiency / scaling
Air-quality extremes come from the `weather_1d` continuous aggregate. Solar peak comes from the raw `weather` table because the aggregates only retain a daily *average* of `solarwatts`; this is the only raw-table scan and it runs solely in the hourly background job, never on a request. Page loads remain a single indexed read of `almanac_cache` with a 1-hour HTTP cache. No frontend changes were needed — the UI already referenced these JSON fields.
