### PR TITLE
Almanac: derive AQI cards in GetAlmanac via pkg/aqi (no SQL formula)

### DIFF
--- a/internal/controllers/restserver/handlers.go
+++ b/internal/controllers/restserver/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chrissnell/remoteweather/internal/database"
 	"github.com/chrissnell/remoteweather/internal/log"
 	"github.com/chrissnell/remoteweather/internal/types"
+	"github.com/chrissnell/remoteweather/pkg/aqi"
 	"github.com/chrissnell/remoteweather/pkg/config"
 	"github.com/chrissnell/remoteweather/pkg/lunar"
 	"github.com/chrissnell/remoteweather/pkg/responseformat"
@@ -1337,7 +1338,9 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Map cache rows to almanac structure
+	// Map cache rows to almanac structure. The cache stores measured extremes
+	// (including the indoor PM2.5 max); the AQI cards are derived below.
+	var highPM25In *AlmanacRecord
 	for _, row := range cacheRows {
 		record := &AlmanacRecord{
 			Value:     row.Value,
@@ -1368,12 +1371,33 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 			almanac.HighPM10In = record
 		case "high_co2":
 			almanac.HighCO2 = record
-		case "high_aqi_pm25":
-			almanac.HighAQIPM25 = record
-		case "high_aqi_pm10":
-			almanac.HighAQIPM10 = record
-		case "high_aqi_pm25_in":
-			almanac.HighAQIPM25In = record
+		case "high_pm25_in":
+			highPM25In = record
+		}
+	}
+
+	// Derive the AQI extremes from the PM extremes using the same functions the
+	// live dashboard uses, so AQI is computed in exactly one place (pkg/aqi).
+	// AQI is monotonic in PM concentration, so the peak AQI is the AQI of the
+	// peak PM, carried at that reading's timestamp.
+	if almanac.HighPM25 != nil {
+		almanac.HighAQIPM25 = &AlmanacRecord{
+			Value:     float32(getOrCalculateAQIPM25(types.Reading{PM25: almanac.HighPM25.Value})),
+			Timestamp: almanac.HighPM25.Timestamp,
+		}
+	}
+	if almanac.HighPM10In != nil {
+		almanac.HighAQIPM10 = &AlmanacRecord{
+			Value:     float32(getOrCalculateAQIPM10(types.Reading{PM10InAQIN: almanac.HighPM10In.Value})),
+			Timestamp: almanac.HighPM10In.Timestamp,
+		}
+	}
+	// The live view has no indoor-AQI path, so reuse the shared pkg/aqi formula
+	// (the same one getOrCalculateAQIPM25 calls) on the indoor PM2.5 max.
+	if highPM25In != nil {
+		almanac.HighAQIPM25In = &AlmanacRecord{
+			Value:     float32(aqi.CalculatePM25(highPM25In.Value)),
+			Timestamp: highPM25In.Timestamp,
 		}
 	}
 
@@ -1383,8 +1407,8 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 	// See: https://github.com/your-repo/issues/XXX
 	_ = h.getSnowBaseDistance(website) // Keep for future use
 
-	// Note: Air quality metrics are now loaded from almanac_cache table above
-	// No need for additional queries - cache is refreshed hourly by PostgreSQL job
+	// PM/CO2 extremes come from almanac_cache (refreshed hourly); the AQI cards
+	// are derived from the PM extremes above. No per-request DB queries here.
 
 	// Set caching headers - almanac data changes infrequently
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/controllers/restserver/transform.go
+++ b/internal/controllers/restserver/transform.go
@@ -225,7 +225,9 @@ func getOrCalculateAQIPM10(r types.Reading) int32 {
 	if r.AQIPM10AQIN > 0 {
 		return r.AQIPM10AQIN
 	}
-	// PM10 isn't currently in the Reading struct, so return 0
-	// TODO: Add PM10 field to Reading struct if PM10 sensors are added
+	// Otherwise calculate from PM10 if available
+	if r.PM10InAQIN > 0 {
+		return aqi.CalculatePM10(r.PM10InAQIN)
+	}
 	return 0
 }

--- a/internal/controllers/restserver/transform_aqi_test.go
+++ b/internal/controllers/restserver/transform_aqi_test.go
@@ -1,0 +1,41 @@
+package restserver
+
+import (
+	"testing"
+
+	"github.com/chrissnell/remoteweather/internal/types"
+	"github.com/chrissnell/remoteweather/pkg/aqi"
+)
+
+func TestGetOrCalculateAQIPM25(t *testing.T) {
+	// Stored AQI is preferred when present.
+	if got := getOrCalculateAQIPM25(types.Reading{AQIPM25AQIN: 142, PM25: 5}); got != 142 {
+		t.Errorf("stored AQI: got %d, want 142", got)
+	}
+	// Otherwise computed from PM2.5 via pkg/aqi.
+	if got, want := getOrCalculateAQIPM25(types.Reading{PM25: 35.4}), aqi.CalculatePM25(35.4); got != want {
+		t.Errorf("computed AQI: got %d, want %d", got, want)
+	}
+	// No data -> 0.
+	if got := getOrCalculateAQIPM25(types.Reading{}); got != 0 {
+		t.Errorf("no data: got %d, want 0", got)
+	}
+}
+
+func TestGetOrCalculateAQIPM10(t *testing.T) {
+	// Stored AQI is preferred when present.
+	if got := getOrCalculateAQIPM10(types.Reading{AQIPM10AQIN: 75, PM10InAQIN: 10}); got != 75 {
+		t.Errorf("stored AQI: got %d, want 75", got)
+	}
+	// Regression guard: previously stubbed to 0; must now compute from PM10.
+	if got, want := getOrCalculateAQIPM10(types.Reading{PM10InAQIN: 154}), aqi.CalculatePM10(154); got != want {
+		t.Errorf("computed AQI: got %d, want %d", got, want)
+	}
+	if got := getOrCalculateAQIPM10(types.Reading{PM10InAQIN: 154}); got == 0 {
+		t.Error("computed PM10 AQI is 0; the stub was not fixed")
+	}
+	// No data -> 0.
+	if got := getOrCalculateAQIPM10(types.Reading{}); got != 0 {
+		t.Errorf("no data: got %d, want 0", got)
+	}
+}

--- a/migrations/weather/029_almanac_store_pm_only.down.sql
+++ b/migrations/weather/029_almanac_store_pm_only.down.sql
@@ -1,0 +1,109 @@
+-- Revert to the 028 behavior: store the device-reported AQI columns directly and
+-- drop the indoor PM2.5 max row.
+CREATE OR REPLACE FUNCTION refresh_almanac_cache_single(p_stationname TEXT)
+RETURNS void AS $$
+BEGIN
+    DELETE FROM almanac_cache WHERE stationname = p_stationname;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_temp', max_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_outtemp IS NOT NULL
+    ORDER BY max_outtemp DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_temp', min_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outtemp IS NOT NULL
+    ORDER BY min_outtemp ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp, wind_dir)
+    SELECT p_stationname, 'high_wind_speed', max_windspeed, bucket, winddir
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_windspeed IS NOT NULL
+    ORDER BY max_windspeed DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_hour', period_rain, bucket
+    FROM weather_1h
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_day', period_rain, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_barometer', min_barometer, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_barometer > 0
+    ORDER BY min_barometer ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_humidity', min_outhumidity, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outhumidity > 0
+    ORDER BY min_outhumidity ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_solar', solarwatts, time
+    FROM weather
+    WHERE stationname = p_stationname AND solarwatts IS NOT NULL AND solarwatts > 0
+    ORDER BY solarwatts DESC
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25', max_pm25, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25 > 0
+    ORDER BY max_pm25 DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm10_in', max_pm10_in_aqin, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm10_in_aqin > 0
+    ORDER BY max_pm10_in_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_co2', max_co2, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_co2 > 0
+    ORDER BY max_co2 DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_aqi_pm25', max_aqi_pm25_aqin::real, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_aqi_pm25_aqin > 0
+    ORDER BY max_aqi_pm25_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_aqi_pm10', max_aqi_pm10_aqin::real, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_aqi_pm10_aqin > 0
+    ORDER BY max_aqi_pm10_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_aqi_pm25_in', max_aqi_pm25_in::real, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_aqi_pm25_in > 0
+    ORDER BY max_aqi_pm25_in DESC NULLS LAST
+    LIMIT 1;
+
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT refresh_almanac_cache();

--- a/migrations/weather/029_almanac_store_pm_only.up.sql
+++ b/migrations/weather/029_almanac_store_pm_only.up.sql
@@ -1,0 +1,124 @@
+-- Almanac AQI is derived in the application (GetAlmanac) from the PM extremes
+-- using the same pkg/aqi functions the live dashboard uses, so the cache stores
+-- only measured quantities — never a computed AQI. This replaces the refresh so
+-- it stops writing high_aqi_* rows and instead records the indoor PM2.5 max
+-- (high_pm25_in) the handler needs to derive the indoor AQI card.
+
+-- Drop the SQL AQI helpers if an earlier iteration created them; the EPA formula
+-- lives only in pkg/aqi now.
+DROP FUNCTION IF EXISTS calculate_aqi_pm25(real);
+DROP FUNCTION IF EXISTS calculate_aqi_pm10(real);
+
+CREATE OR REPLACE FUNCTION refresh_almanac_cache_single(p_stationname TEXT)
+RETURNS void AS $$
+BEGIN
+    -- Delete existing data for this station
+    DELETE FROM almanac_cache WHERE stationname = p_stationname;
+
+    -- Highest temperature - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_temp', max_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_outtemp IS NOT NULL
+    ORDER BY max_outtemp DESC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest temperature - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_temp', min_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outtemp IS NOT NULL
+    ORDER BY min_outtemp ASC NULLS LAST
+    LIMIT 1;
+
+    -- Highest wind speed - use weather_1d for speed (note: winddir is circular_avg per day, not exact)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp, wind_dir)
+    SELECT p_stationname, 'high_wind_speed', max_windspeed, bucket, winddir
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_windspeed IS NOT NULL
+    ORDER BY max_windspeed DESC NULLS LAST
+    LIMIT 1;
+
+    -- Max rain in 1 hour
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_hour', period_rain, bucket
+    FROM weather_1h
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    -- Max rain in 1 day
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_day', period_rain, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest barometer - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_barometer', min_barometer, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_barometer > 0
+    ORDER BY min_barometer ASC NULLS LAST
+    LIMIT 1;
+
+    -- Lowest humidity - use weather_1d for speed
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_humidity', min_outhumidity, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outhumidity > 0
+    ORDER BY min_outhumidity ASC NULLS LAST
+    LIMIT 1;
+
+    -- Highest solar radiation - sourced from the raw weather table (the
+    -- continuous aggregates keep only a daily average of solarwatts). Runs in
+    -- the hourly background job, never on a page request.
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_solar', solarwatts, time
+    FROM weather
+    WHERE stationname = p_stationname AND solarwatts IS NOT NULL AND solarwatts > 0
+    ORDER BY solarwatts DESC
+    LIMIT 1;
+
+    -- Highest PM2.5 (outdoor)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25', max_pm25, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25 > 0
+    ORDER BY max_pm25 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest indoor PM2.5 (not shown directly; used to derive the indoor AQI card)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25_in', max_pm25_in, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25_in > 0
+    ORDER BY max_pm25_in DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest PM10 - sourced from the AQIN sensor (the only PM10 reading we record)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm10_in', max_pm10_in_aqin, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm10_in_aqin > 0
+    ORDER BY max_pm10_in_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest CO2
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_co2', max_co2, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_co2 > 0
+    ORDER BY max_co2 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Note: AQI extremes (high_aqi_pm25 / high_aqi_pm10 / high_aqi_pm25_in) are
+    -- derived in GetAlmanac from the PM extremes above via pkg/aqi.
+    -- Note: Snow metrics are calculated separately as they require base_distance parameter
+
+END;
+$$ LANGUAGE plpgsql;
+
+-- Repopulate the cache so stale high_aqi_* rows are removed and high_pm25_in is added.
+SELECT refresh_almanac_cache();


### PR DESCRIPTION
## Summary
Reworked per review: AQI is **derived in `GetAlmanac`** from the PM extremes using the same `pkg/aqi` path the live dashboard uses — no EPA formula duplicated into SQL, no AQI stored in the DB.

## Changes
- **`GetAlmanac`** derives `high_aqi_pm25` / `high_aqi_pm10` / `high_aqi_pm25_in` from the PM extremes via `getOrCalculateAQIPM25` / `getOrCalculateAQIPM10` (the live-view helpers) and `pkg/aqi` for indoor. AQI is monotonic in PM, so peak AQI = AQI(peak PM), carried at that reading's timestamp.
- **Fixed `getOrCalculateAQIPM10`**, which was stubbed to `return 0` (stale "PM10 isn't in the Reading struct" comment) even though `Reading.PM10InAQIN` exists — PM10 AQI was broken everywhere, including the live dashboard. Now computes from `PM10InAQIN`.
- **Migration 029** stores only measured quantities: drops the `high_aqi_*` rows and the `calculate_aqi_*` SQL functions, and adds the indoor PM2.5 max (`high_pm25_in`) the handler needs to derive the indoor AQI card.
- Tests for both AQI helpers, incl. a regression guard on the PM10 stub.

## Notes
The almanac derives AQI from PM rather than honoring a device-reported AQI; for the all-time peak that's well-defined. Pairs with #36 (hide cards with no data).

## Verification
`go build ./...`, `go vet`, and the new tests pass.