### PR TITLE
Almanac: hide cards for metrics the station doesn't measure

### DIFF
--- a/internal/controllers/restserver/assets/js/weather-app.js.tmpl
+++ b/internal/controllers/restserver/assets/js/weather-app.js.tmpl
@@ -169,15 +169,28 @@ const WeatherApp = (function() {
             return `${directions[index]} (${Math.round(degrees)}°)`;
         };
 
-        // Helper function to update metric
+        // Helper function to show/hide a metric card based on data availability
+        const setCardVisible = (valueEl, visible) => {
+            const card = valueEl ? valueEl.closest('.metric-item') : null;
+            if (card) card.style.display = visible ? '' : 'none';
+        };
+
+        // Helper function to update metric; hides the card when the station has
+        // no record for it (no sensor) instead of showing a placeholder.
         const updateMetric = (valueId, timeId, record, precision = 1) => {
             const valueEl = document.getElementById(valueId);
             const timeEl = document.getElementById(timeId);
 
-            if (valueEl && record) {
+            if (!record) {
+                setCardVisible(valueEl, false);
+                return;
+            }
+            setCardVisible(valueEl, true);
+
+            if (valueEl) {
                 valueEl.textContent = record.value.toFixed(precision);
             }
-            if (timeEl && record) {
+            if (timeEl) {
                 timeEl.textContent = formatTimestamp(record.timestamp);
             }
         };
@@ -191,9 +204,10 @@ const WeatherApp = (function() {
         updateMetric('almanac-high-solar', 'almanac-high-solar-time', almanac.high_solar, 0);
         updateMetric('almanac-low-humidity', 'almanac-low-humidity-time', almanac.low_humidity, 0);
 
-        // Update wind with direction
+        // Update wind with direction (own block due to the extra direction field)
+        const windValueEl = document.getElementById('almanac-high-wind');
         if (almanac.high_wind_speed) {
-            const windValueEl = document.getElementById('almanac-high-wind');
+            setCardVisible(windValueEl, true);
             const windDirEl = document.getElementById('almanac-high-wind-dir');
             const windTimeEl = document.getElementById('almanac-high-wind-time');
 
@@ -202,6 +216,8 @@ const WeatherApp = (function() {
                 windDirEl.textContent = `from ${getWindDirection(almanac.high_wind_speed.wind_dir)}`;
             }
             if (windTimeEl) windTimeEl.textContent = formatTimestamp(almanac.high_wind_speed.timestamp);
+        } else {
+            setCardVisible(windValueEl, false);
         }
 
         // Update snow metrics if enabled


### PR DESCRIPTION
## Summary
Per request: don't show almanac cards when the station lacks the sensor. Previously every card rendered with a `--` placeholder even when there was no data.

## Change
Frontend only (`weather-app.js.tmpl`). `updateMetric` now hides the card's `.metric-item` when the API returns no record for that metric, and shows it when a record is present; the wind card gets the same treatment. The API already omits empty metrics (`omitempty`), so no backend change is needed. Cards reappear automatically if data starts arriving.

## Effect
A station that only reports, say, outdoor PM2.5 + CO2 will show those almanac cards (plus AQI PM2.5 once #35 lands) and no longer render empty Highest PM10 / AQI PM10 / Indoor AQI PM2.5 / Solar cards.

## Verification
JS syntax-checked with node (templates stripped); restserver package builds.
