### PR TITLE
migrate: don't print success message after status command

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -144,6 +144,7 @@ func main() {
 		if err := showStatus(migrator); err != nil {
 			log.Fatalf("Status command failed: %v", err)
 		}
+		return
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", *command)
 		showHelp()


### PR DESCRIPTION
The `status` command is read-only — it just reports the current version and pending migrations. It was falling through to the shared `Migration completed successfully` line, which is misleading since no migration runs.

Return after `showStatus` succeeds, matching how the `version` command already returns early.

Closes GRA-194.