### PR TITLE
Almanac: AirGradient PM10/TVOC + remove Indoor AQI PM2.5 card

### DIFF
--- a/internal/controllers/restserver/assets/js/weather-app.js.tmpl
+++ b/internal/controllers/restserver/assets/js/weather-app.js.tmpl
@@ -218,7 +218,6 @@ const WeatherApp = (function() {
             updateMetric('almanac-high-co2', 'almanac-high-co2-time', almanac.high_co2, 0);
             updateMetric('almanac-high-aqi-pm25', 'almanac-high-aqi-pm25-time', almanac.high_aqi_pm25, 0);
             updateMetric('almanac-high-aqi-pm10', 'almanac-high-aqi-pm10-time', almanac.high_aqi_pm10, 0);
-            updateMetric('almanac-high-aqi-pm25-in', 'almanac-high-aqi-pm25-in-time', almanac.high_aqi_pm25_in, 0);
         }
     };
 

--- a/internal/controllers/restserver/assets/js/weather-app.js.tmpl
+++ b/internal/controllers/restserver/assets/js/weather-app.js.tmpl
@@ -216,6 +216,7 @@ const WeatherApp = (function() {
             updateMetric('almanac-high-pm25', 'almanac-high-pm25-time', almanac.high_pm25, 1);
             updateMetric('almanac-high-pm10', 'almanac-high-pm10-time', almanac.high_pm10_in, 1);
             updateMetric('almanac-high-co2', 'almanac-high-co2-time', almanac.high_co2, 0);
+            updateMetric('almanac-high-tvoc', 'almanac-high-tvoc-time', almanac.high_tvoc, 0);
             updateMetric('almanac-high-aqi-pm25', 'almanac-high-aqi-pm25-time', almanac.high_aqi_pm25, 0);
             updateMetric('almanac-high-aqi-pm10', 'almanac-high-aqi-pm10-time', almanac.high_aqi_pm10, 0);
         }

--- a/internal/controllers/restserver/assets/weather-station.html.tmpl
+++ b/internal/controllers/restserver/assets/weather-station.html.tmpl
@@ -1211,11 +1211,6 @@
                 <div class="metric-value" id="almanac-high-aqi-pm10">--</div>
                 <div class="metric-sub almanac-timestamp" id="almanac-high-aqi-pm10-time">--</div>
               </div>
-              <div class="metric-item">
-                <div class="metric-label">Highest Indoor AQI PM2.5</div>
-                <div class="metric-value" id="almanac-high-aqi-pm25-in">--</div>
-                <div class="metric-sub almanac-timestamp" id="almanac-high-aqi-pm25-in-time">--</div>
-              </div>
               {{ end }}
             </div>
           </div>

--- a/internal/controllers/restserver/assets/weather-station.html.tmpl
+++ b/internal/controllers/restserver/assets/weather-station.html.tmpl
@@ -1202,6 +1202,11 @@
                 <div class="metric-sub almanac-timestamp" id="almanac-high-co2-time">--</div>
               </div>
               <div class="metric-item">
+                <div class="metric-label">Highest TVOC</div>
+                <div class="metric-value" id="almanac-high-tvoc">--</div><span class="metric-unit">index</span>
+                <div class="metric-sub almanac-timestamp" id="almanac-high-tvoc-time">--</div>
+              </div>
+              <div class="metric-item">
                 <div class="metric-label">Highest AQI PM2.5</div>
                 <div class="metric-value" id="almanac-high-aqi-pm25">--</div>
                 <div class="metric-sub almanac-timestamp" id="almanac-high-aqi-pm25-time">--</div>

--- a/internal/controllers/restserver/handlers.go
+++ b/internal/controllers/restserver/handlers.go
@@ -17,7 +17,6 @@ import (
 	"github.com/chrissnell/remoteweather/internal/database"
 	"github.com/chrissnell/remoteweather/internal/log"
 	"github.com/chrissnell/remoteweather/internal/types"
-	"github.com/chrissnell/remoteweather/pkg/aqi"
 	"github.com/chrissnell/remoteweather/pkg/config"
 	"github.com/chrissnell/remoteweather/pkg/lunar"
 	"github.com/chrissnell/remoteweather/pkg/responseformat"
@@ -1280,7 +1279,6 @@ type AlmanacData struct {
 	HighCO2       *AlmanacRecord `json:"high_co2,omitempty"`
 	HighAQIPM25   *AlmanacRecord `json:"high_aqi_pm25,omitempty"`
 	HighAQIPM10   *AlmanacRecord `json:"high_aqi_pm10,omitempty"`
-	HighAQIPM25In *AlmanacRecord `json:"high_aqi_pm25_in,omitempty"`
 }
 
 // AlmanacCacheRow represents a row from the almanac_cache table
@@ -1381,7 +1379,6 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 	almanac.HighPM25 = aqRecords["high_pm25"]
 	almanac.HighPM10In = aqRecords["high_pm10_in"]
 	almanac.HighCO2 = aqRecords["high_co2"]
-	highPM25In := aqRecords["high_pm25_in"]
 
 	// Derive the AQI extremes from the PM extremes using the same functions the
 	// live dashboard uses, so AQI is computed in exactly one place (pkg/aqi).
@@ -1397,14 +1394,6 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 		almanac.HighAQIPM10 = &AlmanacRecord{
 			Value:     float32(getOrCalculateAQIPM10(types.Reading{PM10InAQIN: almanac.HighPM10In.Value})),
 			Timestamp: almanac.HighPM10In.Timestamp,
-		}
-	}
-	// The live view has no indoor-AQI path, so reuse the shared pkg/aqi formula
-	// (the same one getOrCalculateAQIPM25 calls) on the indoor PM2.5 max.
-	if highPM25In != nil {
-		almanac.HighAQIPM25In = &AlmanacRecord{
-			Value:     float32(aqi.CalculatePM25(highPM25In.Value)),
-			Timestamp: highPM25In.Timestamp,
 		}
 	}
 

--- a/internal/controllers/restserver/handlers.go
+++ b/internal/controllers/restserver/handlers.go
@@ -1277,6 +1277,7 @@ type AlmanacData struct {
 	HighPM25      *AlmanacRecord `json:"high_pm25,omitempty"`
 	HighPM10In    *AlmanacRecord `json:"high_pm10_in,omitempty"`
 	HighCO2       *AlmanacRecord `json:"high_co2,omitempty"`
+	HighTVOC      *AlmanacRecord `json:"high_tvoc,omitempty"`
 	HighAQIPM25   *AlmanacRecord `json:"high_aqi_pm25,omitempty"`
 	HighAQIPM10   *AlmanacRecord `json:"high_aqi_pm10,omitempty"`
 }
@@ -1379,6 +1380,7 @@ func (h *Handlers) GetAlmanac(w http.ResponseWriter, req *http.Request) {
 	almanac.HighPM25 = aqRecords["high_pm25"]
 	almanac.HighPM10In = aqRecords["high_pm10_in"]
 	almanac.HighCO2 = aqRecords["high_co2"]
+	almanac.HighTVOC = aqRecords["high_tvoc"]
 
 	// Derive the AQI extremes from the PM extremes using the same functions the
 	// live dashboard uses, so AQI is computed in exactly one place (pkg/aqi).

--- a/migrations/weather/030_almanac_airgradient_pm10.down.sql
+++ b/migrations/weather/030_almanac_airgradient_pm10.down.sql
@@ -1,0 +1,95 @@
+-- Revert to the 029 behavior: PM10 only from pm10_in_aqin, and re-add the
+-- indoor PM2.5 max (high_pm25_in).
+CREATE OR REPLACE FUNCTION refresh_almanac_cache_single(p_stationname TEXT)
+RETURNS void AS $$
+BEGIN
+    DELETE FROM almanac_cache WHERE stationname = p_stationname;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_temp', max_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_outtemp IS NOT NULL
+    ORDER BY max_outtemp DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_temp', min_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outtemp IS NOT NULL
+    ORDER BY min_outtemp ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp, wind_dir)
+    SELECT p_stationname, 'high_wind_speed', max_windspeed, bucket, winddir
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_windspeed IS NOT NULL
+    ORDER BY max_windspeed DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_hour', period_rain, bucket
+    FROM weather_1h
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_day', period_rain, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_barometer', min_barometer, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_barometer > 0
+    ORDER BY min_barometer ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_humidity', min_outhumidity, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outhumidity > 0
+    ORDER BY min_outhumidity ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_solar', solarwatts, time
+    FROM weather
+    WHERE stationname = p_stationname AND solarwatts IS NOT NULL AND solarwatts > 0
+    ORDER BY solarwatts DESC
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25', max_pm25, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25 > 0
+    ORDER BY max_pm25 DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25_in', max_pm25_in, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25_in > 0
+    ORDER BY max_pm25_in DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm10_in', max_pm10_in_aqin, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm10_in_aqin > 0
+    ORDER BY max_pm10_in_aqin DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_co2', max_co2, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_co2 > 0
+    ORDER BY max_co2 DESC NULLS LAST
+    LIMIT 1;
+
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT refresh_almanac_cache();

--- a/migrations/weather/030_almanac_airgradient_pm10.up.sql
+++ b/migrations/weather/030_almanac_airgradient_pm10.up.sql
@@ -1,0 +1,110 @@
+-- PM10 lives in different columns depending on the air quality device:
+--   * Ambient AQIN sensors report it as pm10_in_aqin
+--   * AirGradient sensors report it in extrafloat2 (see the airgradient station
+--     mapping, which packs PM10/PM1/TVOC/NOx into the extrafloat fields)
+-- The almanac only read pm10_in_aqin, so PM10 (and the derived AQI PM10) were
+-- always blank for AirGradient devices. Source PM10 per station type.
+--
+-- Also drops high_pm25_in: the indoor AQI PM2.5 card has been removed, so the
+-- indoor PM2.5 max is no longer needed.
+CREATE OR REPLACE FUNCTION refresh_almanac_cache_single(p_stationname TEXT)
+RETURNS void AS $$
+BEGIN
+    DELETE FROM almanac_cache WHERE stationname = p_stationname;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_temp', max_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_outtemp IS NOT NULL
+    ORDER BY max_outtemp DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_temp', min_outtemp, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outtemp IS NOT NULL
+    ORDER BY min_outtemp ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp, wind_dir)
+    SELECT p_stationname, 'high_wind_speed', max_windspeed, bucket, winddir
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_windspeed IS NOT NULL
+    ORDER BY max_windspeed DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_hour', period_rain, bucket
+    FROM weather_1h
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'max_rain_day', period_rain, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND period_rain IS NOT NULL
+    ORDER BY period_rain DESC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_barometer', min_barometer, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_barometer > 0
+    ORDER BY min_barometer ASC NULLS LAST
+    LIMIT 1;
+
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'low_humidity', min_outhumidity, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND min_outhumidity > 0
+    ORDER BY min_outhumidity ASC NULLS LAST
+    LIMIT 1;
+
+    -- Highest solar radiation - from the raw weather table (aggregates keep only a daily average)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_solar', solarwatts, time
+    FROM weather
+    WHERE stationname = p_stationname AND solarwatts IS NOT NULL AND solarwatts > 0
+    ORDER BY solarwatts DESC
+    LIMIT 1;
+
+    -- Highest PM2.5 (outdoor)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm25', max_pm25, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_pm25 > 0
+    ORDER BY max_pm25 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest PM10 - AirGradient stores it in extrafloat2; Ambient AQIN in pm10_in_aqin.
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_pm10_in', val, bucket
+    FROM (
+        SELECT bucket,
+               CASE WHEN stationtype = 'airgradient' THEN max_extrafloat2
+                    ELSE max_pm10_in_aqin END AS val
+        FROM weather_1d
+        WHERE stationname = p_stationname
+    ) s
+    WHERE val > 0
+    ORDER BY val DESC NULLS LAST
+    LIMIT 1;
+
+    -- Highest CO2
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_co2', max_co2, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND max_co2 > 0
+    ORDER BY max_co2 DESC NULLS LAST
+    LIMIT 1;
+
+    -- Note: AQI extremes (high_aqi_pm25 / high_aqi_pm10) are derived in
+    -- GetAlmanac from the PM extremes above via pkg/aqi.
+    -- Note: Snow metrics are calculated separately as they require base_distance parameter
+
+END;
+$$ LANGUAGE plpgsql;
+
+-- Repopulate so PM10 fills in for AirGradient devices and high_pm25_in is dropped.
+SELECT refresh_almanac_cache();

--- a/migrations/weather/030_almanac_airgradient_pm10.up.sql
+++ b/migrations/weather/030_almanac_airgradient_pm10.up.sql
@@ -99,6 +99,14 @@ BEGIN
     ORDER BY max_co2 DESC NULLS LAST
     LIMIT 1;
 
+    -- Highest TVOC index - AirGradient only (stored in extrafloat3)
+    INSERT INTO almanac_cache (stationname, metric_name, value, timestamp)
+    SELECT p_stationname, 'high_tvoc', max_extrafloat3, bucket
+    FROM weather_1d
+    WHERE stationname = p_stationname AND stationtype = 'airgradient' AND max_extrafloat3 > 0
+    ORDER BY max_extrafloat3 DESC NULLS LAST
+    LIMIT 1;
+
     -- Note: AQI extremes (high_aqi_pm25 / high_aqi_pm10) are derived in
     -- GetAlmanac from the PM extremes above via pkg/aqi.
     -- Note: Snow metrics are calculated separately as they require base_distance parameter


### PR DESCRIPTION
## Summary
Almanac air-quality fixes/additions from issue feedback.

### Highest PM10 / Highest AQI PM10 were broken for AirGradient devices
AirGradient sensors map readings into the `extrafloat*` columns — PM2.5 → `pm25`, CO2 → `co2`, **PM10 → `extrafloat2`** (`internal/weatherstations/airgradient/station.go`). The almanac only read PM10 from the Ambient `pm10_in_aqin` column (empty for AirGradient), so Highest PM10 and the derived AQI PM10 were blank. The refresh now sources PM10 per station type: `extrafloat2` for `airgradient`, `pm10_in_aqin` otherwise; AQI PM10 still derives in `GetAlmanac` via `pkg/aqi`.

### Added Highest TVOC
TVOC index is stored in `extrafloat3` by the AirGradient integration. New Highest TVOC card sourced from it (AirGradient only).

### Removed Highest Indoor AQI PM2.5
Removed across the stack (HTML, JS, `AlmanacData` field, handler derive) and dropped the unused `high_pm25_in` cache row.

## Notes
PM10/TVOC sources are station-type-guarded — no-ops for non-AirGradient stations. Needs a deploy + the v30 weather migration (re-runs the refresh).

## Verification
`go build ./...`, `go vet`, package tests, and a node syntax check of the JS template all pass.