### PR TITLE
Expose primary device coordinates on /stationinfo

### DIFF
--- a/internal/controllers/restserver/handlers.go
+++ b/internal/controllers/restserver/handlers.go
@@ -1125,9 +1125,17 @@ func (h *Handlers) GetStationInfo(w http.ResponseWriter, req *http.Request) {
 		Stations:    make([]StationInfoItem, 0),
 	}
 
-	// Set weather device (primary device for this website)
+	// Set weather device (primary device for this website) and its location
+	// so clients can center a radar map on the station.
 	if website.DeviceID != nil {
 		response.WeatherDevice = website.DeviceID
+		for _, device := range currentDevices {
+			if device.ID == *website.DeviceID {
+				response.Latitude = device.Latitude
+				response.Longitude = device.Longitude
+				break
+			}
+		}
 	}
 
 	// Set snow device if enabled

--- a/internal/controllers/restserver/types.go
+++ b/internal/controllers/restserver/types.go
@@ -256,6 +256,10 @@ type StationInfoResponse struct {
 	WeatherDevice      *int              `json:"weather_device,omitempty"`
 	SnowDevice         *string           `json:"snow_device,omitempty"`
 	AirQualityDevice   *string           `json:"air_quality_device,omitempty"`
+	// Latitude/Longitude of the primary weather device, used by clients to
+	// center a radar map on the station. Omitted when the device has no location.
+	Latitude  float64 `json:"latitude,omitempty"`
+	Longitude float64 `json:"longitude,omitempty"`
 }
 
 // Alert represents a weather alert for JSON output


### PR DESCRIPTION
Adds `latitude` and `longitude` of the primary weather device to the `/stationinfo` response so clients (e.g. the iOS app's new Radar tab) can center a map on the station. Fields use `omitempty`, so they are omitted when the device has no location.

Paired with the iOS app Radar tab (chrissnell/RemoteWeather.app `feature/radar-tab`), which reads these to center a 50-mile radar map.

- `internal/controllers/restserver/types.go` — new `Latitude`/`Longitude` fields on `StationInfoResponse`
- `internal/controllers/restserver/handlers.go` — populate them from the primary device

Existing `restserver` tests pass; `go vet` clean.