### PR TITLE
Configurable send/upload intervals for APRS, WU, PWSWeather, Aeris

### DIFF
--- a/internal/controllers/aerisweather/controller.go
+++ b/internal/controllers/aerisweather/controller.go
@@ -342,20 +342,14 @@ func (a *AerisWeatherController) refreshForecastPeriodically(device config.Devic
 	}
 
 	// We will refresh our forecasts four times in every period.
-	// For example: for a daily forecast, we refresh every 6 hours.
-	refreshInterval := spanInterval / 4
-
-	// An optional per-device override replaces the derived interval, but never
-	// refreshes more often than once per hour to stay within API limits.
-	if device.AerisRefreshInterval > 0 {
-		override := time.Duration(device.AerisRefreshInterval) * time.Second
-		if override < minAerisRefreshInterval {
-			log.Warnf("Aeris refresh interval %ds for device %s is below the minimum of %v; using the minimum",
-				device.AerisRefreshInterval, device.Name, minAerisRefreshInterval)
-			override = minAerisRefreshInterval
-		}
-		refreshInterval = override
-	}
+	// For example: for a daily forecast, we refresh every 6 hours. An optional
+	// per-device override replaces this derived interval, but never refreshes
+	// more often than once per hour to stay within API limits.
+	refreshInterval := controllers.ResolveInterval(
+		time.Duration(device.AerisRefreshInterval)*time.Second,
+		spanInterval/4,
+		minAerisRefreshInterval,
+		"Aeris ("+device.Name+")")
 
 	log.Infof("Starting Aeris Weather fetcher for device %s: %v hours, every %v minutes",
 		device.Name, numPeriods*periodHours, refreshInterval.Minutes())

--- a/internal/controllers/aerisweather/controller.go
+++ b/internal/controllers/aerisweather/controller.go
@@ -24,6 +24,11 @@ import (
 	"gorm.io/gorm"
 )
 
+// minAerisRefreshInterval is the shortest allowed forecast refresh period for a
+// per-device override. Forecasts change slowly, so hourly is plenty and keeps
+// us well within API rate limits.
+const minAerisRefreshInterval = time.Hour
+
 // AerisWeatherController holds our AerisWeather configuration
 type AerisWeatherController struct {
 	ctx            context.Context
@@ -340,7 +345,19 @@ func (a *AerisWeatherController) refreshForecastPeriodically(device config.Devic
 	// For example: for a daily forecast, we refresh every 6 hours.
 	refreshInterval := spanInterval / 4
 
-	log.Infof("Starting Aeris Weather fetcher for device %s: %v hours, every %v minutes", 
+	// An optional per-device override replaces the derived interval, but never
+	// refreshes more often than once per hour to stay within API limits.
+	if device.AerisRefreshInterval > 0 {
+		override := time.Duration(device.AerisRefreshInterval) * time.Second
+		if override < minAerisRefreshInterval {
+			log.Warnf("Aeris refresh interval %ds for device %s is below the minimum of %v; using the minimum",
+				device.AerisRefreshInterval, device.Name, minAerisRefreshInterval)
+			override = minAerisRefreshInterval
+		}
+		refreshInterval = override
+	}
+
+	log.Infof("Starting Aeris Weather fetcher for device %s: %v hours, every %v minutes",
 		device.Name, numPeriods*periodHours, refreshInterval.Minutes())
 
 	ticker := time.NewTicker(refreshInterval)

--- a/internal/controllers/aprs/controller.go
+++ b/internal/controllers/aprs/controller.go
@@ -30,11 +30,15 @@ const (
 	// aprsInitialDelay is how long a per-device worker waits before sending its
 	// first report after starting.
 	aprsInitialDelay = 15 * time.Second
-	// aprsSendInterval is how often each device transmits a weather report.
+	// aprsSendInterval is the default report cadence used when a device has no
+	// per-device interval configured.
 	aprsSendInterval = 5 * time.Minute
 	// aprsReconcileInterval is how often the supervisor re-reads the device list
 	// to start/stop workers as devices are enabled or disabled in the UI.
 	aprsReconcileInterval = 1 * time.Minute
+	// minAPRSInterval is the fastest report cadence allowed for a per-device
+	// override; APRS-IS and CWOP ask for no more than one report every 5 min.
+	minAPRSInterval = 5 * time.Minute
 )
 
 // aprsDeviceReady reports whether a device is fully configured for APRS
@@ -262,7 +266,11 @@ func (a *Controller) reconcileWorkers(ctx context.Context, wg *sync.WaitGroup, w
 func (a *Controller) sendDeviceReports(ctx context.Context, wg *sync.WaitGroup, name string) {
 	defer wg.Done()
 
-	ticker := time.NewTicker(aprsSendInterval)
+	// Use the device-specific report interval, or the default when unset. The
+	// interval is re-read each cycle so UI edits take effect without a restart,
+	// consistent with the per-cycle config re-read in sendReportForDevice.
+	interval := a.reportInterval(name)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	// Send initial report after a short delay.
@@ -280,11 +288,31 @@ func (a *Controller) sendDeviceReports(ctx context.Context, wg *sync.WaitGroup, 
 		select {
 		case <-ticker.C:
 			a.sendReportForDevice(ctx, wg, name)
+			if next := a.reportInterval(name); next != interval {
+				interval = next
+				ticker.Reset(interval)
+			}
 		case <-ctx.Done():
 			log.Infof("Stopping APRS reports for %s", name)
 			return
 		}
 	}
+}
+
+// reportInterval returns the device's configured APRS report interval, guarded
+// by the APRS-IS/CWOP minimum, falling back to the default when the interval is
+// unset or the device can't be read.
+func (a *Controller) reportInterval(name string) time.Duration {
+	device, err := a.configProvider.GetDevice(name)
+	if err != nil || device == nil {
+		return aprsSendInterval
+	}
+	seconds := controllers.ResolveUploadInterval(
+		device.APRSUploadInterval,
+		int(aprsSendInterval/time.Second),
+		int(minAPRSInterval/time.Second),
+		"APRS ("+name+")")
+	return time.Duration(seconds) * time.Second
 }
 
 // sendReportForDevice re-reads the device's current configuration and, if it is

--- a/internal/controllers/aprs/controller_test.go
+++ b/internal/controllers/aprs/controller_test.go
@@ -2,6 +2,7 @@ package aprs
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -16,7 +17,8 @@ func TestMain(m *testing.M) {
 }
 
 // fakeProvider is a minimal ConfigProvider that returns a settable device list.
-// Only the methods reconcileWorkers touches are implemented; the rest are
+// It implements the methods the worker touches (GetDevices for reconciliation,
+// GetDevice for per-cycle re-reads and report-interval lookups); the rest are
 // promoted from the (nil) embedded interface and must not be called.
 type fakeProvider struct {
 	config.ConfigProvider
@@ -36,6 +38,18 @@ func (f *fakeProvider) GetDevices() ([]config.DeviceData, error) {
 	out := make([]config.DeviceData, len(f.devices))
 	copy(out, f.devices)
 	return out, nil
+}
+
+func (f *fakeProvider) GetDevice(name string) (*config.DeviceData, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.devices {
+		if f.devices[i].Name == name {
+			d := f.devices[i]
+			return &d, nil
+		}
+	}
+	return nil, fmt.Errorf("device %s not found", name)
 }
 
 func readyDevice(name string) config.DeviceData {

--- a/internal/controllers/management/assets/index.html
+++ b/internal/controllers/management/assets/index.html
@@ -215,9 +215,14 @@
                       API Client Secret
                       <input type="password" id="aeris-api-client-secret" placeholder="your-client-secret" />
                     </label>
+                    <label>
+                      Forecast Refresh Interval (seconds, optional)
+                      <input type="number" id="aeris-refresh-interval" min="3600" placeholder="auto (derived from forecast period)" />
+                    </label>
+                    <p class="help-text">Leave blank to refresh automatically (four times per forecast period). Minimum 3600 seconds (1 hour) when set.</p>
                   </div>
                 </div>
-                
+
                 <!-- Weather Underground -->
                 <div class="service-group" id="wu-group">
                   <div class="service-header">
@@ -234,9 +239,14 @@
                       API Key
                       <input type="password" id="wu-api-key" placeholder="your-api-key" />
                     </label>
+                    <label>
+                      Upload Interval (seconds)
+                      <input type="number" id="wu-upload-interval" min="60" placeholder="300" />
+                    </label>
+                    <p class="help-text">Default 300 seconds. Minimum 60 seconds.</p>
                   </div>
                 </div>
-                
+
                 <!-- PWS Weather -->
                 <div class="service-group" id="pws-group">
                   <div class="service-header">
@@ -253,9 +263,14 @@
                       API Key
                       <input type="password" id="pws-api-key" placeholder="your-api-key" />
                     </label>
+                    <label>
+                      Upload Interval (seconds)
+                      <input type="number" id="pws-upload-interval" min="60" placeholder="60" />
+                    </label>
+                    <p class="help-text">Default 60 seconds. Minimum 60 seconds.</p>
                   </div>
                 </div>
-                
+
                 <!-- APRS -->
                 <div class="service-group" id="aprs-group">
                   <div class="service-header">
@@ -267,6 +282,10 @@
                     <label>
                       Callsign
                       <input type="text" id="aprs-callsign" placeholder="N0CALL" />
+                    </label>
+                    <label>
+                      Report Interval (seconds)
+                      <input type="number" id="aprs-upload-interval" min="300" placeholder="300" />
                     </label>
                     <label>
                       Transport

--- a/internal/controllers/management/assets/js/management-weather-stations.js
+++ b/internal/controllers/management/assets/js/management-weather-stations.js
@@ -66,23 +66,27 @@ const ManagementWeatherStations = (function() {
       aerisEnabled: document.getElementById('aeris-enabled'),
       aerisApiClientId: document.getElementById('aeris-api-client-id'),
       aerisApiClientSecret: document.getElementById('aeris-api-client-secret'),
+      aerisRefreshInterval: document.getElementById('aeris-refresh-interval'),
       aerisFields: document.getElementById('aeris-fields'),
-      
+
       // Weather Underground
       wuEnabled: document.getElementById('wu-enabled'),
       wuStationId: document.getElementById('wu-station-id'),
       wuApiKey: document.getElementById('wu-api-key'),
+      wuUploadInterval: document.getElementById('wu-upload-interval'),
       wuFields: document.getElementById('wu-fields'),
-      
+
       // PWS Weather
       pwsEnabled: document.getElementById('pws-enabled'),
       pwsStationId: document.getElementById('pws-station-id'),
       pwsApiKey: document.getElementById('pws-api-key'),
+      pwsUploadInterval: document.getElementById('pws-upload-interval'),
       pwsFields: document.getElementById('pws-fields'),
-      
+
       // APRS fields
       aprsEnabled: document.getElementById('aprs-enabled'),
       aprsCallsign: document.getElementById('aprs-callsign'),
+      aprsUploadInterval: document.getElementById('aprs-upload-interval'),
       aprsServer: document.getElementById('aprs-server'),
       aprsConfigFields: document.getElementById('aprs-config-fields'),
       aprsTransport: document.getElementById('aprs-transport'),
@@ -480,6 +484,10 @@ const ManagementWeatherStations = (function() {
       device.aeris_enabled = true;
       device.aeris_api_client_id = aerisApiClientId;
       device.aeris_api_client_secret = aerisApiClientSecret;
+      const aerisRefresh = parseInt(formElements.aerisRefreshInterval.value, 10);
+      if (!Number.isNaN(aerisRefresh) && aerisRefresh > 0) {
+        device.aeris_refresh_interval = aerisRefresh;
+      }
     }
     
     // Weather Underground
@@ -494,6 +502,10 @@ const ManagementWeatherStations = (function() {
       device.wu_enabled = true;
       device.wu_station_id = wuStationId;
       device.wu_password = wuApiKey;
+      const wuInterval = parseInt(formElements.wuUploadInterval.value, 10);
+      if (!Number.isNaN(wuInterval) && wuInterval > 0) {
+        device.wu_upload_interval = wuInterval;
+      }
     }
     
     // PWS Weather
@@ -508,6 +520,10 @@ const ManagementWeatherStations = (function() {
       device.pws_enabled = true;
       device.pws_station_id = pwsStationId;
       device.pws_password = pwsApiKey;
+      const pwsInterval = parseInt(formElements.pwsUploadInterval.value, 10);
+      if (!Number.isNaN(pwsInterval) && pwsInterval > 0) {
+        device.pws_upload_interval = pwsInterval;
+      }
     }
     
     // APRS configuration
@@ -524,6 +540,11 @@ const ManagementWeatherStations = (function() {
       device.aprs_enabled = true;
       device.aprs_callsign = aprsCallsign;
       device.aprs_transport = aprsTransport;
+
+      const aprsInterval = parseInt(formElements.aprsUploadInterval.value, 10);
+      if (!Number.isNaN(aprsInterval) && aprsInterval > 0) {
+        device.aprs_upload_interval = aprsInterval;
+      }
 
       if (aprsTransport === 'kiss') {
         const kissConnection = formElements.aprsKISSConnection.value;
@@ -801,6 +822,7 @@ const ManagementWeatherStations = (function() {
     formElements.aerisEnabled.checked = device.aeris_enabled || false;
     formElements.aerisApiClientId.value = device.aeris_api_client_id || '';
     formElements.aerisApiClientSecret.value = device.aeris_api_client_secret || '';
+    formElements.aerisRefreshInterval.value = device.aeris_refresh_interval || '';
     ManagementUtils.setElementVisibility(
       formElements.aerisFields,
       device.aeris_enabled
@@ -811,6 +833,7 @@ const ManagementWeatherStations = (function() {
     formElements.wuEnabled.checked = device.wu_enabled || false;
     formElements.wuStationId.value = device.wu_station_id || '';
     formElements.wuApiKey.value = device.wu_password || '';
+    formElements.wuUploadInterval.value = device.wu_upload_interval || '';
     ManagementUtils.setElementVisibility(
       formElements.wuFields,
       device.wu_enabled
@@ -821,6 +844,7 @@ const ManagementWeatherStations = (function() {
     formElements.pwsEnabled.checked = device.pws_enabled || false;
     formElements.pwsStationId.value = device.pws_station_id || '';
     formElements.pwsApiKey.value = device.pws_password || '';
+    formElements.pwsUploadInterval.value = device.pws_upload_interval || '';
     ManagementUtils.setElementVisibility(
       formElements.pwsFields,
       device.pws_enabled
@@ -835,6 +859,7 @@ const ManagementWeatherStations = (function() {
   function populateAPRSFields(device) {
     formElements.aprsEnabled.checked = device.aprs_enabled || false;
     formElements.aprsCallsign.value = device.aprs_callsign || '';
+    formElements.aprsUploadInterval.value = device.aprs_upload_interval || '';
 
     // Set server dropdown value
     if (device.aprs_server) {

--- a/internal/controllers/pwsweather/controller.go
+++ b/internal/controllers/pwsweather/controller.go
@@ -68,11 +68,10 @@ func (p *PWSWeatherController) sendPeriodicReports() {
 		if device.PWSEnabled && device.PWSStationID != "" && device.PWSPassword != "" {
 			log.Infof("Starting PWS Weather monitoring for device: %s (Station ID: %s)", device.Name, device.PWSStationID)
 			
-			// Use device-specific upload interval or default
-			uploadInterval := "60"
-			if device.PWSUploadInterval > 0 {
-				uploadInterval = strconv.Itoa(device.PWSUploadInterval)
-			}
+			// Use device-specific upload interval or default (60s), guarded by
+			// the minimum-interval floor.
+			uploadInterval := strconv.Itoa(controllers.ResolveUploadInterval(
+				device.PWSUploadInterval, 60, controllers.MinPWSUploadInterval, "PWS Weather"))
 
 			// Create a copy of device for closure
 			deviceCopy := device

--- a/internal/controllers/weather_service_utils.go
+++ b/internal/controllers/weather_service_utils.go
@@ -84,19 +84,34 @@ const (
 	MinWUUploadInterval  = 60
 )
 
-// ResolveUploadInterval returns the configured interval (seconds) or the given
-// default when unset (<=0), clamped up to the minimum. It logs a warning when a
-// configured value is raised to the minimum.
+// ResolveUploadInterval returns the configured interval (seconds) when set
+// (>0), otherwise the given default. A configured value below the minimum is
+// raised to the minimum with a warning. The default is used as-is and never
+// clamped, so it can be a derived value that legitimately falls below the guard.
 func ResolveUploadInterval(configured, def, min int, service string) int {
-	interval := def
-	if configured > 0 {
-		interval = configured
+	if configured <= 0 {
+		return def
 	}
-	if interval < min {
-		log.Warnf("%s upload interval %ds is below the minimum of %ds; using %ds", service, interval, min, min)
-		interval = min
+	if configured < min {
+		log.Warnf("%s upload interval %ds is below the minimum of %ds; using %ds", service, configured, min, min)
+		return min
 	}
-	return interval
+	return configured
+}
+
+// ResolveInterval is the time.Duration form of ResolveUploadInterval, for
+// services that work in durations or whose default is derived at runtime (e.g.
+// Aeris' per-period forecast refresh). Same semantics: only a configured
+// override is clamped to the minimum; the default is returned untouched.
+func ResolveInterval(configured, def, min time.Duration, service string) time.Duration {
+	if configured <= 0 {
+		return def
+	}
+	if configured < min {
+		log.Warnf("%s interval %v is below the minimum of %v; using %v", service, configured, min, min)
+		return min
+	}
+	return configured
 }
 
 // StartPeriodicReports starts periodic weather reports using the provided send function

--- a/internal/controllers/weather_service_utils.go
+++ b/internal/controllers/weather_service_utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/chrissnell/remoteweather/internal/database"
+	"github.com/chrissnell/remoteweather/internal/log"
 	"github.com/chrissnell/remoteweather/pkg/config"
 	"go.uber.org/zap"
 )
@@ -73,6 +74,29 @@ func SetWeatherServiceDefaults(wsc *WeatherServiceConfig) {
 	if wsc.UploadInterval == "" {
 		wsc.UploadInterval = "60"
 	}
+}
+
+// Minimum upload intervals (seconds) guard against abusive rates that would
+// violate third-party service terms. PWSWeather and Weather Underground both
+// expect no more than one standard update per minute.
+const (
+	MinPWSUploadInterval = 60
+	MinWUUploadInterval  = 60
+)
+
+// ResolveUploadInterval returns the configured interval (seconds) or the given
+// default when unset (<=0), clamped up to the minimum. It logs a warning when a
+// configured value is raised to the minimum.
+func ResolveUploadInterval(configured, def, min int, service string) int {
+	interval := def
+	if configured > 0 {
+		interval = configured
+	}
+	if interval < min {
+		log.Warnf("%s upload interval %ds is below the minimum of %ds; using %ds", service, interval, min, min)
+		interval = min
+	}
+	return interval
 }
 
 // StartPeriodicReports starts periodic weather reports using the provided send function

--- a/internal/controllers/weather_service_utils_test.go
+++ b/internal/controllers/weather_service_utils_test.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/chrissnell/remoteweather/internal/log"
+)
+
+func TestMain(m *testing.M) {
+	// ResolveUploadInterval logs via the package-level logger when clamping, so
+	// the global logger must be initialized before tests run.
+	_ = log.Init(false)
+	m.Run()
+}
+
+func TestResolveUploadInterval(t *testing.T) {
+	cases := []struct {
+		name                    string
+		configured, def, minVal int
+		want                    int
+	}{
+		{"unset uses default", 0, 60, MinPWSUploadInterval, 60},
+		{"configured above minimum", 120, 60, MinPWSUploadInterval, 120},
+		{"configured below minimum clamps up", 10, 60, MinPWSUploadInterval, MinPWSUploadInterval},
+		{"wu unset uses 300 default", 0, 300, MinWUUploadInterval, 300},
+		{"negative treated as unset", -5, 300, MinWUUploadInterval, 300},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ResolveUploadInterval(c.configured, c.def, c.minVal, "Test Service")
+			if got != c.want {
+				t.Errorf("ResolveUploadInterval(%d,%d,%d) = %d, want %d",
+					c.configured, c.def, c.minVal, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/controllers/wunderground/controller.go
+++ b/internal/controllers/wunderground/controller.go
@@ -68,11 +68,10 @@ func (p *WeatherUndergroundController) sendPeriodicReports() {
 		if device.WUEnabled && device.WUStationID != "" && device.WUPassword != "" {
 			log.Infof("Starting Weather Underground monitoring for device: %s (Station ID: %s)", device.Name, device.WUStationID)
 			
-			// Use device-specific upload interval or default
-			uploadInterval := "60"
-			if device.WUUploadInterval > 0 {
-				uploadInterval = strconv.Itoa(device.WUUploadInterval)
-			}
+			// Use device-specific upload interval or default (300s, matching the
+			// schema default), guarded by the minimum-interval floor.
+			uploadInterval := strconv.Itoa(controllers.ResolveUploadInterval(
+				device.WUUploadInterval, 300, controllers.MinWUUploadInterval, "Weather Underground"))
 
 			// Create a copy of device for closure
 			deviceCopy := device

--- a/migrations/config/027_add_configurable_intervals.down.sql
+++ b/migrations/config/027_add_configurable_intervals.down.sql
@@ -1,0 +1,4 @@
+-- SQLite doesn't support DROP COLUMN in older versions; the columns are
+-- harmless if unused. For PostgreSQL:
+ALTER TABLE devices DROP COLUMN IF EXISTS aprs_upload_interval;
+ALTER TABLE devices DROP COLUMN IF EXISTS aeris_refresh_interval;

--- a/migrations/config/027_add_configurable_intervals.up.sql
+++ b/migrations/config/027_add_configurable_intervals.up.sql
@@ -1,0 +1,8 @@
+-- Migration 027: Configurable send/upload intervals
+-- APRS gains a per-device upload interval (seconds); Aeris gains an optional
+-- forecast refresh override (seconds). Both default to the values in use today:
+-- APRS 300s (5 min), and Aeris 0 which means "derive from the forecast period"
+-- (the existing 4x-per-period behavior).
+
+ALTER TABLE devices ADD COLUMN aprs_upload_interval INTEGER DEFAULT 300;
+ALTER TABLE devices ADD COLUMN aeris_refresh_interval INTEGER DEFAULT 0;

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -212,11 +212,12 @@ type DeviceData struct {
 	WUAPIEndpoint    string `json:"wu_api_endpoint,omitempty"`
 
 	// APRS additional fields
-	APRSPasscode    string `json:"aprs_passcode,omitempty"`
-	APRSSymbolTable string `json:"aprs_symbol_table,omitempty"`
-	APRSSymbolCode  string `json:"aprs_symbol_code,omitempty"`
-	APRSComment     string `json:"aprs_comment,omitempty"`
-	APRSServer      string `json:"aprs_server,omitempty"`
+	APRSPasscode       string `json:"aprs_passcode,omitempty"`
+	APRSSymbolTable    string `json:"aprs_symbol_table,omitempty"`
+	APRSSymbolCode     string `json:"aprs_symbol_code,omitempty"`
+	APRSComment        string `json:"aprs_comment,omitempty"`
+	APRSServer         string `json:"aprs_server,omitempty"`
+	APRSUploadInterval int    `json:"aprs_upload_interval,omitempty"` // seconds between reports; default 300
 
 	// APRS KISS transport fields. When APRSTransport is "kiss", weather packets
 	// are sent over KISS to a TNC (serial or network) instead of APRS-IS.
@@ -233,6 +234,7 @@ type DeviceData struct {
 	AerisAPIClientID     string `json:"aeris_api_client_id,omitempty"`
 	AerisAPIClientSecret string `json:"aeris_api_client_secret,omitempty"`
 	AerisAPIEndpoint     string `json:"aeris_api_endpoint,omitempty"`
+	AerisRefreshInterval int    `json:"aeris_refresh_interval,omitempty"` // seconds between forecast refreshes; 0 = derive from forecast period
 
 	// WeatherLink Live fields
 	WLLHost          string `json:"wll_host,omitempty"`

--- a/pkg/config/provider_service_intervals_test.go
+++ b/pkg/config/provider_service_intervals_test.go
@@ -1,0 +1,81 @@
+package config
+
+import "testing"
+
+// TestDeviceServiceConfigRoundTrip verifies that per-device weather service
+// configuration — including the configurable send/upload intervals — is
+// persisted and read back through AddDevice/GetDevice and UpdateDevice.
+func TestDeviceServiceConfigRoundTrip(t *testing.T) {
+	p := newTestProvider(t)
+
+	dev := &DeviceData{
+		Name:                 "svc-station",
+		Type:                 "campbellscientific",
+		Enabled:              true,
+		PWSEnabled:           true,
+		PWSStationID:         "PWS123",
+		PWSPassword:          "pws-secret",
+		PWSUploadInterval:    120,
+		WUEnabled:            true,
+		WUStationID:          "WU456",
+		WUPassword:           "wu-secret",
+		WUUploadInterval:     600,
+		AerisEnabled:         true,
+		AerisAPIClientID:     "aeris-id",
+		AerisAPIClientSecret: "aeris-secret",
+		AerisRefreshInterval: 7200,
+		APRSEnabled:          true,
+		APRSCallsign:         "N0CALL",
+		APRSUploadInterval:   900,
+	}
+	if err := p.AddDevice(dev); err != nil {
+		t.Fatalf("AddDevice: %v", err)
+	}
+
+	got, err := p.GetDevice("svc-station")
+	if err != nil {
+		t.Fatalf("GetDevice: %v", err)
+	}
+
+	intChecks := []struct {
+		name      string
+		got, want int
+	}{
+		{"pws_upload_interval", got.PWSUploadInterval, 120},
+		{"wu_upload_interval", got.WUUploadInterval, 600},
+		{"aeris_refresh_interval", got.AerisRefreshInterval, 7200},
+		{"aprs_upload_interval", got.APRSUploadInterval, 900},
+	}
+	for _, c := range intChecks {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+		}
+	}
+	if !got.PWSEnabled || !got.WUEnabled || !got.AerisEnabled {
+		t.Errorf("service enablement not persisted: pws=%v wu=%v aeris=%v", got.PWSEnabled, got.WUEnabled, got.AerisEnabled)
+	}
+	if got.PWSStationID != "PWS123" || got.WUStationID != "WU456" || got.AerisAPIClientID != "aeris-id" {
+		t.Errorf("service credentials not persisted: %q %q %q", got.PWSStationID, got.WUStationID, got.AerisAPIClientID)
+	}
+
+	// Updating the intervals must persist too.
+	got.PWSUploadInterval = 300
+	got.APRSUploadInterval = 1200
+	got.AerisRefreshInterval = 0
+	if err := p.UpdateDevice("svc-station", got); err != nil {
+		t.Fatalf("UpdateDevice: %v", err)
+	}
+	after, err := p.GetDevice("svc-station")
+	if err != nil {
+		t.Fatalf("GetDevice after update: %v", err)
+	}
+	if after.PWSUploadInterval != 300 {
+		t.Errorf("after update pws_upload_interval = %d, want 300", after.PWSUploadInterval)
+	}
+	if after.APRSUploadInterval != 1200 {
+		t.Errorf("after update aprs_upload_interval = %d, want 1200", after.APRSUploadInterval)
+	}
+	if after.AerisRefreshInterval != 0 {
+		t.Errorf("after update aeris_refresh_interval = %d, want 0", after.AerisRefreshInterval)
+	}
+}

--- a/pkg/config/provider_service_intervals_test.go
+++ b/pkg/config/provider_service_intervals_test.go
@@ -16,13 +16,16 @@ func TestDeviceServiceConfigRoundTrip(t *testing.T) {
 		PWSStationID:         "PWS123",
 		PWSPassword:          "pws-secret",
 		PWSUploadInterval:    120,
+		PWSAPIEndpoint:       "https://pws.example.com/submit",
 		WUEnabled:            true,
 		WUStationID:          "WU456",
 		WUPassword:           "wu-secret",
 		WUUploadInterval:     600,
+		WUAPIEndpoint:        "https://wu.example.com/submit",
 		AerisEnabled:         true,
 		AerisAPIClientID:     "aeris-id",
 		AerisAPIClientSecret: "aeris-secret",
+		AerisAPIEndpoint:     "https://aeris.example.com/",
 		AerisRefreshInterval: 7200,
 		APRSEnabled:          true,
 		APRSCallsign:         "N0CALL",
@@ -56,6 +59,13 @@ func TestDeviceServiceConfigRoundTrip(t *testing.T) {
 	}
 	if got.PWSStationID != "PWS123" || got.WUStationID != "WU456" || got.AerisAPIClientID != "aeris-id" {
 		t.Errorf("service credentials not persisted: %q %q %q", got.PWSStationID, got.WUStationID, got.AerisAPIClientID)
+	}
+	// GetDevice must return the *_api_endpoint columns, matching GetDevices.
+	if got.PWSAPIEndpoint != "https://pws.example.com/submit" ||
+		got.WUAPIEndpoint != "https://wu.example.com/submit" ||
+		got.AerisAPIEndpoint != "https://aeris.example.com/" {
+		t.Errorf("service API endpoints not returned by GetDevice: pws=%q wu=%q aeris=%q",
+			got.PWSAPIEndpoint, got.WUAPIEndpoint, got.AerisAPIEndpoint)
 	}
 
 	// Updating the intervals must persist too.

--- a/pkg/config/provider_sqlite.go
+++ b/pkg/config/provider_sqlite.go
@@ -1116,12 +1116,12 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 		       d.wind_dir_correction, d.base_snow_distance, d.website_id,
 		       d.latitude, d.longitude, d.altitude, d.timezone, d.aprs_enabled, d.aprs_callsign,
 		       d.tls_cert_file, d.tls_key_file, d.path,
-		       d.pws_enabled, d.pws_station_id, d.pws_password, d.pws_upload_interval,
-		       d.wu_enabled, d.wu_station_id, d.wu_password, d.wu_upload_interval,
+		       d.pws_enabled, d.pws_station_id, d.pws_password, d.pws_upload_interval, d.pws_api_endpoint,
+		       d.wu_enabled, d.wu_station_id, d.wu_password, d.wu_upload_interval, d.wu_api_endpoint,
 		       d.aprs_passcode, d.aprs_symbol_table, d.aprs_symbol_code, d.aprs_comment, d.aprs_server, d.aprs_upload_interval,
 		       d.aprs_transport, d.aprs_kiss_connection, d.aprs_kiss_serial_device, d.aprs_kiss_serial_baud,
 		       d.aprs_kiss_tcp_address, d.aprs_kiss_path, d.aprs_kiss_destination,
-		       d.aeris_enabled, d.aeris_api_client_id, d.aeris_api_client_secret, d.aeris_refresh_interval
+		       d.aeris_enabled, d.aeris_api_client_id, d.aeris_api_client_secret, d.aeris_api_endpoint, d.aeris_refresh_interval
 		FROM devices d
 		JOIN configs c ON d.config_id = c.id
 		WHERE d.name = ?
@@ -1137,12 +1137,12 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 
 	// PWS Weather fields
 	var pwsEnabled sql.NullBool
-	var pwsStationID, pwsPassword sql.NullString
+	var pwsStationID, pwsPassword, pwsAPIEndpoint sql.NullString
 	var pwsUploadInterval sql.NullInt64
 
 	// Weather Underground fields
 	var wuEnabled sql.NullBool
-	var wuStationID, wuPassword sql.NullString
+	var wuStationID, wuPassword, wuAPIEndpoint sql.NullString
 	var wuUploadInterval sql.NullInt64
 
 	// APRS additional fields
@@ -1156,7 +1156,7 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 
 	// Aeris Weather fields
 	var aerisEnabled sql.NullBool
-	var aerisAPIClientID, aerisAPIClientSecret sql.NullString
+	var aerisAPIClientID, aerisAPIClientSecret, aerisAPIEndpoint sql.NullString
 	var aerisRefreshInterval sql.NullInt64
 
 	err := s.db.QueryRow(query, name).Scan(
@@ -1164,12 +1164,12 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 		&serialDevice, &baud, &windDirCorrection,
 		&baseSnowDistance, &websiteID, &latitude, &longitude, &altitude, &timezone,
 		&aprsEnabled, &aprsCallsign, &tlsCertFile, &tlsKeyFile, &path,
-		&pwsEnabled, &pwsStationID, &pwsPassword, &pwsUploadInterval,
-		&wuEnabled, &wuStationID, &wuPassword, &wuUploadInterval,
+		&pwsEnabled, &pwsStationID, &pwsPassword, &pwsUploadInterval, &pwsAPIEndpoint,
+		&wuEnabled, &wuStationID, &wuPassword, &wuUploadInterval, &wuAPIEndpoint,
 		&aprsPasscode, &aprsSymbolTable, &aprsSymbolCode, &aprsComment, &aprsServer, &aprsUploadInterval,
 		&aprsTransport, &aprsKISSConnection, &aprsKISSSerialDevice, &aprsKISSSerialBaud,
 		&aprsKISSTCPAddress, &aprsKISSPath, &aprsKISSDestination,
-		&aerisEnabled, &aerisAPIClientID, &aerisAPIClientSecret, &aerisRefreshInterval,
+		&aerisEnabled, &aerisAPIClientID, &aerisAPIClientSecret, &aerisAPIEndpoint, &aerisRefreshInterval,
 	)
 
 	if err != nil {
@@ -1247,6 +1247,9 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 	if pwsUploadInterval.Valid {
 		device.PWSUploadInterval = int(pwsUploadInterval.Int64)
 	}
+	if pwsAPIEndpoint.Valid {
+		device.PWSAPIEndpoint = pwsAPIEndpoint.String
+	}
 
 	// Set Weather Underground fields
 	device.WUEnabled = wuEnabled.Bool
@@ -1258,6 +1261,9 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 	}
 	if wuUploadInterval.Valid {
 		device.WUUploadInterval = int(wuUploadInterval.Int64)
+	}
+	if wuAPIEndpoint.Valid {
+		device.WUAPIEndpoint = wuAPIEndpoint.String
 	}
 
 	// Set APRS additional fields
@@ -1310,6 +1316,9 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 	}
 	if aerisAPIClientSecret.Valid {
 		device.AerisAPIClientSecret = aerisAPIClientSecret.String
+	}
+	if aerisAPIEndpoint.Valid {
+		device.AerisAPIEndpoint = aerisAPIEndpoint.String
 	}
 	if aerisRefreshInterval.Valid {
 		device.AerisRefreshInterval = int(aerisRefreshInterval.Int64)

--- a/pkg/config/provider_sqlite.go
+++ b/pkg/config/provider_sqlite.go
@@ -136,6 +136,7 @@ CREATE TABLE devices (
     aprs_symbol_code CHAR(1) DEFAULT '_',
     aprs_comment TEXT,
     aprs_server TEXT,
+    aprs_upload_interval INTEGER DEFAULT 300,
     -- APRS KISS transport fields
     aprs_transport TEXT DEFAULT 'aprs-is',
     aprs_kiss_connection TEXT,
@@ -149,6 +150,7 @@ CREATE TABLE devices (
     aeris_api_client_id TEXT,
     aeris_api_client_secret TEXT,
     aeris_api_endpoint TEXT,
+    aeris_refresh_interval INTEGER DEFAULT 0,
     FOREIGN KEY (config_id) REFERENCES configs(id) ON DELETE CASCADE,
     UNIQUE(config_id, name)
 );
@@ -403,10 +405,10 @@ func (s *SQLiteProvider) GetDevices() ([]DeviceData, error) {
 		       tls_cert_file, tls_key_file, path,
 		       pws_enabled, pws_station_id, pws_password, pws_upload_interval, pws_api_endpoint,
 		       wu_enabled, wu_station_id, wu_password, wu_upload_interval, wu_api_endpoint,
-		       aprs_passcode, aprs_symbol_table, aprs_symbol_code, aprs_comment, aprs_server,
+		       aprs_passcode, aprs_symbol_table, aprs_symbol_code, aprs_comment, aprs_server, aprs_upload_interval,
 		       aprs_transport, aprs_kiss_connection, aprs_kiss_serial_device, aprs_kiss_serial_baud,
 		       aprs_kiss_tcp_address, aprs_kiss_path, aprs_kiss_destination,
-		       aeris_enabled, aeris_api_client_id, aeris_api_client_secret, aeris_api_endpoint
+		       aeris_enabled, aeris_api_client_id, aeris_api_client_secret, aeris_api_endpoint, aeris_refresh_interval
 		FROM devices
 		WHERE config_id = (SELECT id FROM configs WHERE name = 'default')
 		ORDER BY name
@@ -441,6 +443,7 @@ func (s *SQLiteProvider) GetDevices() ([]DeviceData, error) {
 
 		// APRS additional fields
 		var aprsPasscode, aprsSymbolTable, aprsSymbolCode, aprsComment, aprsServer sql.NullString
+		var aprsUploadInterval sql.NullInt64
 
 		// APRS KISS transport fields
 		var aprsTransport, aprsKISSConnection, aprsKISSSerialDevice sql.NullString
@@ -450,6 +453,7 @@ func (s *SQLiteProvider) GetDevices() ([]DeviceData, error) {
 		// Aeris Weather fields
 		var aerisEnabled sql.NullBool
 		var aerisAPIClientID, aerisAPIClientSecret, aerisAPIEndpoint sql.NullString
+		var aerisRefreshInterval sql.NullInt64
 
 		err := rows.Scan(
 			&device.ID, &device.Name, &device.Type, &enabled, &hostname, &port,
@@ -458,10 +462,10 @@ func (s *SQLiteProvider) GetDevices() ([]DeviceData, error) {
 			&aprsEnabled, &aprsCallsign, &tlsCertFile, &tlsKeyFile, &path,
 			&pwsEnabled, &pwsStationID, &pwsPassword, &pwsUploadInterval, &pwsAPIEndpoint,
 			&wuEnabled, &wuStationID, &wuPassword, &wuUploadInterval, &wuAPIEndpoint,
-			&aprsPasscode, &aprsSymbolTable, &aprsSymbolCode, &aprsComment, &aprsServer,
+			&aprsPasscode, &aprsSymbolTable, &aprsSymbolCode, &aprsComment, &aprsServer, &aprsUploadInterval,
 			&aprsTransport, &aprsKISSConnection, &aprsKISSSerialDevice, &aprsKISSSerialBaud,
 			&aprsKISSTCPAddress, &aprsKISSPath, &aprsKISSDestination,
-			&aerisEnabled, &aerisAPIClientID, &aerisAPIClientSecret, &aerisAPIEndpoint,
+			&aerisEnabled, &aerisAPIClientID, &aerisAPIClientSecret, &aerisAPIEndpoint, &aerisRefreshInterval,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan device row: %w", err)
@@ -575,6 +579,9 @@ func (s *SQLiteProvider) GetDevices() ([]DeviceData, error) {
 		if aprsServer.Valid {
 			device.APRSServer = aprsServer.String
 		}
+		if aprsUploadInterval.Valid {
+			device.APRSUploadInterval = int(aprsUploadInterval.Int64)
+		}
 
 		// Set APRS KISS transport fields
 		if aprsTransport.Valid {
@@ -609,6 +616,9 @@ func (s *SQLiteProvider) GetDevices() ([]DeviceData, error) {
 		}
 		if aerisAPIEndpoint.Valid {
 			device.AerisAPIEndpoint = aerisAPIEndpoint.String
+		}
+		if aerisRefreshInterval.Valid {
+			device.AerisRefreshInterval = int(aerisRefreshInterval.Int64)
 		}
 
 		devices = append(devices, device)
@@ -926,8 +936,13 @@ func (s *SQLiteProvider) insertDevice(tx *sql.Tx, configID int64, device *Device
 			config_id, name, type, enabled, hostname, port, serial_device,
 			baud, wind_dir_correction, base_snow_distance, website_id,
 			latitude, longitude, altitude, timezone, aprs_enabled, aprs_callsign,
-			tls_cert_file, tls_key_file, path
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			tls_cert_file, tls_key_file, path,
+			pws_enabled, pws_station_id, pws_password, pws_upload_interval, pws_api_endpoint,
+			wu_enabled, wu_station_id, wu_password, wu_upload_interval, wu_api_endpoint,
+			aprs_passcode, aprs_symbol_table, aprs_symbol_code, aprs_comment, aprs_server, aprs_upload_interval,
+			aeris_enabled, aeris_api_client_id, aeris_api_client_secret, aeris_api_endpoint, aeris_refresh_interval
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	var websiteID sql.NullInt64
@@ -941,6 +956,10 @@ func (s *SQLiteProvider) insertDevice(tx *sql.Tx, configID int64, device *Device
 		websiteID, device.Latitude, device.Longitude, device.Altitude, nullString(device.Timezone),
 		device.APRSEnabled, device.APRSCallsign,
 		nullString(device.TLSCertPath), nullString(device.TLSKeyPath), nullString(device.Path),
+		device.PWSEnabled, nullString(device.PWSStationID), nullString(device.PWSPassword), device.PWSUploadInterval, nullString(device.PWSAPIEndpoint),
+		device.WUEnabled, nullString(device.WUStationID), nullString(device.WUPassword), device.WUUploadInterval, nullString(device.WUAPIEndpoint),
+		nullString(device.APRSPasscode), nullString(device.APRSSymbolTable), nullString(device.APRSSymbolCode), nullString(device.APRSComment), nullString(device.APRSServer), device.APRSUploadInterval,
+		device.AerisEnabled, nullString(device.AerisAPIClientID), nullString(device.AerisAPIClientSecret), nullString(device.AerisAPIEndpoint), device.AerisRefreshInterval,
 	)
 	return err
 }
@@ -1099,10 +1118,10 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 		       d.tls_cert_file, d.tls_key_file, d.path,
 		       d.pws_enabled, d.pws_station_id, d.pws_password, d.pws_upload_interval,
 		       d.wu_enabled, d.wu_station_id, d.wu_password, d.wu_upload_interval,
-		       d.aprs_passcode, d.aprs_symbol_table, d.aprs_symbol_code, d.aprs_comment, d.aprs_server,
+		       d.aprs_passcode, d.aprs_symbol_table, d.aprs_symbol_code, d.aprs_comment, d.aprs_server, d.aprs_upload_interval,
 		       d.aprs_transport, d.aprs_kiss_connection, d.aprs_kiss_serial_device, d.aprs_kiss_serial_baud,
 		       d.aprs_kiss_tcp_address, d.aprs_kiss_path, d.aprs_kiss_destination,
-		       d.aeris_enabled, d.aeris_api_client_id, d.aeris_api_client_secret
+		       d.aeris_enabled, d.aeris_api_client_id, d.aeris_api_client_secret, d.aeris_refresh_interval
 		FROM devices d
 		JOIN configs c ON d.config_id = c.id
 		WHERE d.name = ?
@@ -1128,6 +1147,7 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 
 	// APRS additional fields
 	var aprsPasscode, aprsSymbolTable, aprsSymbolCode, aprsComment, aprsServer sql.NullString
+	var aprsUploadInterval sql.NullInt64
 
 	// APRS KISS transport fields
 	var aprsTransport, aprsKISSConnection, aprsKISSSerialDevice sql.NullString
@@ -1137,6 +1157,7 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 	// Aeris Weather fields
 	var aerisEnabled sql.NullBool
 	var aerisAPIClientID, aerisAPIClientSecret sql.NullString
+	var aerisRefreshInterval sql.NullInt64
 
 	err := s.db.QueryRow(query, name).Scan(
 		&device.ID, &device.Name, &device.Type, &device.Enabled, &hostname, &port,
@@ -1145,10 +1166,10 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 		&aprsEnabled, &aprsCallsign, &tlsCertFile, &tlsKeyFile, &path,
 		&pwsEnabled, &pwsStationID, &pwsPassword, &pwsUploadInterval,
 		&wuEnabled, &wuStationID, &wuPassword, &wuUploadInterval,
-		&aprsPasscode, &aprsSymbolTable, &aprsSymbolCode, &aprsComment, &aprsServer,
+		&aprsPasscode, &aprsSymbolTable, &aprsSymbolCode, &aprsComment, &aprsServer, &aprsUploadInterval,
 		&aprsTransport, &aprsKISSConnection, &aprsKISSSerialDevice, &aprsKISSSerialBaud,
 		&aprsKISSTCPAddress, &aprsKISSPath, &aprsKISSDestination,
-		&aerisEnabled, &aerisAPIClientID, &aerisAPIClientSecret,
+		&aerisEnabled, &aerisAPIClientID, &aerisAPIClientSecret, &aerisRefreshInterval,
 	)
 
 	if err != nil {
@@ -1255,6 +1276,9 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 	if aprsServer.Valid {
 		device.APRSServer = aprsServer.String
 	}
+	if aprsUploadInterval.Valid {
+		device.APRSUploadInterval = int(aprsUploadInterval.Int64)
+	}
 
 	// Set APRS KISS transport fields
 	if aprsTransport.Valid {
@@ -1287,6 +1311,9 @@ func (s *SQLiteProvider) GetDevice(name string) (*DeviceData, error) {
 	if aerisAPIClientSecret.Valid {
 		device.AerisAPIClientSecret = aerisAPIClientSecret.String
 	}
+	if aerisRefreshInterval.Valid {
+		device.AerisRefreshInterval = int(aerisRefreshInterval.Int64)
+	}
 
 	return &device, nil
 }
@@ -1317,9 +1344,15 @@ func (s *SQLiteProvider) AddDevice(device *DeviceData) error {
 			baud, wind_dir_correction, base_snow_distance, website_id,
 			latitude, longitude, altitude, timezone, aprs_enabled, aprs_callsign,
 			tls_cert_file, tls_key_file, path,
+			pws_enabled, pws_station_id, pws_password, pws_upload_interval, pws_api_endpoint,
+			wu_enabled, wu_station_id, wu_password, wu_upload_interval, wu_api_endpoint,
+			aprs_passcode, aprs_symbol_table, aprs_symbol_code, aprs_comment, aprs_server, aprs_upload_interval,
+			aeris_enabled, aeris_api_client_id, aeris_api_client_secret, aeris_api_endpoint, aeris_refresh_interval,
 			aprs_transport, aprs_kiss_connection, aprs_kiss_serial_device, aprs_kiss_serial_baud,
 			aprs_kiss_tcp_address, aprs_kiss_path, aprs_kiss_destination
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?)
 	`
 
 	var websiteID sql.NullInt64
@@ -1333,6 +1366,10 @@ func (s *SQLiteProvider) AddDevice(device *DeviceData) error {
 		websiteID, device.Latitude, device.Longitude, device.Altitude, nullString(device.Timezone),
 		device.APRSEnabled, device.APRSCallsign,
 		nullString(device.TLSCertPath), nullString(device.TLSKeyPath), nullString(device.Path),
+		device.PWSEnabled, nullString(device.PWSStationID), nullString(device.PWSPassword), device.PWSUploadInterval, nullString(device.PWSAPIEndpoint),
+		device.WUEnabled, nullString(device.WUStationID), nullString(device.WUPassword), device.WUUploadInterval, nullString(device.WUAPIEndpoint),
+		nullString(device.APRSPasscode), nullString(device.APRSSymbolTable), nullString(device.APRSSymbolCode), nullString(device.APRSComment), nullString(device.APRSServer), device.APRSUploadInterval,
+		device.AerisEnabled, nullString(device.AerisAPIClientID), nullString(device.AerisAPIClientSecret), nullString(device.AerisAPIEndpoint), device.AerisRefreshInterval,
 		nullString(aprsTransportOrDefault(device.APRSTransport)), nullString(device.APRSKISSConnection),
 		nullString(device.APRSKISSSerialDevice), device.APRSKISSSerialBaud,
 		nullString(device.APRSKISSTCPAddress), nullString(device.APRSKISSPath),
@@ -1372,6 +1409,10 @@ func (s *SQLiteProvider) UpdateDevice(name string, device *DeviceData) error {
 			baud = ?, wind_dir_correction = ?, base_snow_distance = ?, website_id = ?,
 			latitude = ?, longitude = ?, altitude = ?, timezone = ?, aprs_enabled = ?, aprs_callsign = ?,
 			tls_cert_file = ?, tls_key_file = ?, path = ?,
+			pws_enabled = ?, pws_station_id = ?, pws_password = ?, pws_upload_interval = ?, pws_api_endpoint = ?,
+			wu_enabled = ?, wu_station_id = ?, wu_password = ?, wu_upload_interval = ?, wu_api_endpoint = ?,
+			aprs_passcode = ?, aprs_symbol_table = ?, aprs_symbol_code = ?, aprs_comment = ?, aprs_server = ?, aprs_upload_interval = ?,
+			aeris_enabled = ?, aeris_api_client_id = ?, aeris_api_client_secret = ?, aeris_api_endpoint = ?, aeris_refresh_interval = ?,
 			aprs_transport = ?, aprs_kiss_connection = ?, aprs_kiss_serial_device = ?, aprs_kiss_serial_baud = ?,
 			aprs_kiss_tcp_address = ?, aprs_kiss_path = ?, aprs_kiss_destination = ?
 		WHERE name = ?
@@ -1388,6 +1429,10 @@ func (s *SQLiteProvider) UpdateDevice(name string, device *DeviceData) error {
 		websiteID, device.Latitude, device.Longitude, device.Altitude, nullString(device.Timezone),
 		device.APRSEnabled, device.APRSCallsign,
 		nullString(device.TLSCertPath), nullString(device.TLSKeyPath), nullString(device.Path),
+		device.PWSEnabled, nullString(device.PWSStationID), nullString(device.PWSPassword), device.PWSUploadInterval, nullString(device.PWSAPIEndpoint),
+		device.WUEnabled, nullString(device.WUStationID), nullString(device.WUPassword), device.WUUploadInterval, nullString(device.WUAPIEndpoint),
+		nullString(device.APRSPasscode), nullString(device.APRSSymbolTable), nullString(device.APRSSymbolCode), nullString(device.APRSComment), nullString(device.APRSServer), device.APRSUploadInterval,
+		device.AerisEnabled, nullString(device.AerisAPIClientID), nullString(device.AerisAPIClientSecret), nullString(device.AerisAPIEndpoint), device.AerisRefreshInterval,
 		nullString(aprsTransportOrDefault(device.APRSTransport)), nullString(device.APRSKISSConnection),
 		nullString(device.APRSKISSSerialDevice), device.APRSKISSSerialBaud,
 		nullString(device.APRSKISSTCPAddress), nullString(device.APRSKISSPath),


### PR DESCRIPTION
Makes each weather service's report interval configurable per device, keeping today's values as the defaults so unconfigured devices behave exactly as before.

## Changes
- **APRS**: new per-device `aprs_upload_interval` (default 300s), replacing the hardcoded 5-minute ticker. Floored at the 5-minute APRS-IS/CWOP minimum.
- **Aeris**: optional `aeris_refresh_interval` override. When unset, the existing "4x per forecast period" derivation is unchanged. Minimum 1 hour when set.
- **PWSWeather / Weather Underground**: surface the existing interval fields in the management UI; add a shared 60s minimum guard. WU's controller default now matches the 300s schema default (previously fell back to 60s).
- **Persistence fix**: `AddDevice`/`UpdateDevice` previously omitted the per-device PWS/WU/Aeris service columns, so that config never persisted. These are now written alongside the new interval fields.
- **Migration 027** adds `aprs_upload_interval` and `aeris_refresh_interval`.

## Minimum-interval guards
| Service | Default | Minimum |
|---|---|---|
| APRS | 300s | 300s |
| PWSWeather | 60s | 60s |
| Weather Underground | 300s | 60s |
| Aeris | derived (4x/period) | 3600s (when overridden) |

## Tests
- Round-trip persistence test for all four services' config + intervals through Add/Update/Get.
- Table test for the shared minimum-interval guard.